### PR TITLE
fix undici issue with build and package to binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [Unreleased](https://github.com/dotenvx/dotenvx/compare/v0.15.2...main)
+## [Unreleased](https://github.com/dotenvx/dotenvx/compare/v0.15.3...main)
+
+## 0.15.3
+
+* 🐞 fix undici readablestream error ([#65](https://github.com/dotenvx/dotenvx/pull/65))
 
 ## 0.15.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ignore": "^5.3.0",
         "open": "^8.4.2",
         "ora": "^5.4.1",
-        "undici": "^6.6.2",
+        "undici": "^5.28.3",
         "update-notifier": "^5.1.0",
         "winston": "^3.11.0",
         "xxhashjs": "^0.2.2"
@@ -8587,14 +8587,14 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.2.tgz",
-      "integrity": "sha512-vSqvUE5skSxQJ5sztTZ/CdeJb1Wq0Hf44hlYMciqHghvz+K88U0l7D6u1VsndoFgskDcnU+nG3gYmMzJVzd9Qg==",
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ignore": "^5.3.0",
     "open": "^8.4.2",
     "ora": "^5.4.1",
-    "undici": "^6.6.2",
+    "undici": "^5.28.3",
     "update-notifier": "^5.1.0",
     "winston": "^3.11.0",
     "xxhashjs": "^0.2.2"


### PR DESCRIPTION
received error:

```
➜  multiple dotenvx run -- node index.js
pkg/prelude/bootstrap.js:1872
      throw error;
      ^

ReferenceError: ReadableStream is not defined
    at Object.<anonymous> (/snapshot/dotenvx/node_modules/undici/lib/fetch/response.js:507:3)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Module._compile (pkg/prelude/bootstrap.js:1933:32)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at Module.require (pkg/prelude/bootstrap.js:1851:31)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/snapshot/dotenvx/node_modules/undici/lib/fetch/index.js:11:5)
```

downgraded to undici 5