### PR TITLE
Fix command path detection on windows

### DIFF
--- a/src/cli/actions/run.js
+++ b/src/cli/actions/run.js
@@ -4,6 +4,7 @@ const logger = require('./../../shared/logger')
 
 const RunDefault = require('./../../lib/services/runDefault')
 const RunVault = require('./../../lib/services/runVault')
+const helpers = require('./../helpers')
 
 const REPORT_ISSUE_LINK = 'https://github.com/dotenvx/dotenvx/issues/new'
 
@@ -35,7 +36,9 @@ const executeCommand = async function (commandArgs, env) {
   }
 
   try {
-    const systemCommandPath = execa.sync('which', [commandArgs[0]]).stdout
+    const systemCommandPath = helpers.isWindows()
+      ? execa.sync("where.exe", [commandArgs[0]]).stdout
+      : execa.sync('which', [commandArgs[0]]).stdout
     logger.debug(`system command path [${systemCommandPath}]`)
 
     // commandProcess = execa(commandArgs[0], commandArgs.slice(1), {

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -37,10 +37,17 @@ const extractUsernameName = function (url) {
   return parts.slice(-2).join('/')
 }
 
+const isWindows = function () {
+  // Snippet taken from cross-env
+  // https://github.com/kentcdodds/cross-env/blob/master/src/is-windows.js
+  return process.platform === 'win32' || /^(msys|cygwin)$/.test(process.env.OSTYPE)
+}
+
 module.exports = {
   sleep,
   resolvePath,
   pluralize,
   getRemoteOriginUrl,
-  extractUsernameName
+  extractUsernameName,
+  isWindows
 }


### PR DESCRIPTION
Got the error as commented on #92 and @ali-layken in #99. This should fix the error for powershell users.

Haven't thoroughly tested this, but it works on my Win11 VM.
Also noticed that strings in the dotenvx run command don't get parsed right so they arrive with string keys.

Example:
`dotenvx run --env-file=.env.development --env='EXPO_PUBLIC_APP_ENV=development' --env='EXPO_NO_DOTENV=1' --`
Here I have to remove the '' around the value else they won't properly get parsed and set before running the command.
Thats probably a separate windows issue but yeah.