### PR TITLE
use `@inquirer/confirm` instead of every inquirer package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.27.1",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/prompts": "^3.3.0",
+        "@inquirer/confirm": "^2.0.17",
         "arch": "^2.1.1",
         "boxen": "^5.0.0",
         "chalk": "^4.1.2",
@@ -487,46 +487,31 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@inquirer/checkbox": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.5.0.tgz",
-      "integrity": "sha512-3cKJkW1vIZAs4NaS0reFsnpAjP0azffYII4I2R7PTI7ZTMg5Y1at4vzXccOH3762b2c2L4drBhpJpf9uiaGNxA==",
-      "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "figures": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
     "node_modules/@inquirer/confirm": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.15.tgz",
-      "integrity": "sha512-hj8Q/z7sQXsF0DSpLQZVDhWYGN6KLM/gNjjqGkpKwBzljbQofGjn0ueHADy4HUY+OqDHmXuwk/bY+tZyIuuB0w==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.17.tgz",
+      "integrity": "sha512-EqzhGryzmGpy2aJf6LxJVhndxYmFs+m8cxXzf8nejb1DE3sabf6mUgBcp4J0jAUEiAcYzqmkqRr7LPFh/WdnXA==",
       "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "chalk": "^4.1.2"
       },
       "engines": {
         "node": ">=14.18.0"
       }
     },
-    "node_modules/@inquirer/core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.1.1.tgz",
-      "integrity": "sha512-IuJyZQUg75+L5AmopgnzxYrgcU6PJKL0hoIs332G1Gv55CnmZrhG6BzNOeZ5sOsTi1YCGOopw4rYICv74ejMFg==",
+    "node_modules/@inquirer/confirm/node_modules/@inquirer/core": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
+      "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
       "dependencies": {
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/type": "^1.1.6",
         "@types/mute-stream": "^0.0.4",
-        "@types/node": "^20.9.0",
+        "@types/node": "^20.10.7",
         "@types/wrap-ansi": "^3.0.0",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
-        "cli-spinners": "^2.9.1",
+        "cli-spinners": "^2.9.2",
         "cli-width": "^4.1.0",
         "figures": "^3.2.0",
         "mute-stream": "^1.0.0",
@@ -539,7 +524,7 @@
         "node": ">=14.18.0"
       }
     },
-    "node_modules/@inquirer/core/node_modules/signal-exit": {
+    "node_modules/@inquirer/confirm/node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
@@ -550,7 +535,7 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+    "node_modules/@inquirer/confirm/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
@@ -563,114 +548,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/@inquirer/editor": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-1.2.13.tgz",
-      "integrity": "sha512-gBxjqt0B9GLN0j6M/tkEcmcIvB2fo9Cw0f5NRqDTkYyB9AaCzj7qvgG0onQ3GVPbMyMbbP4tWYxrBOaOdKpzNA==",
-      "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
-        "chalk": "^4.1.2",
-        "external-editor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/@inquirer/expand": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-1.1.14.tgz",
-      "integrity": "sha512-yS6fJ8jZYAsxdxuw2c8XTFMTvMR1NxZAw3LxDaFnqh7BZ++wTQ6rSp/2gGJhMacdZ85osb+tHxjVgx7F+ilv5g==",
-      "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
-        "chalk": "^4.1.2",
-        "figures": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/@inquirer/input": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.14.tgz",
-      "integrity": "sha512-tISLGpUKXixIQue7jypNEShrdzJoLvEvZOJ4QRsw5XTfrIYfoWFqAjMQLerGs9CzR86yAI89JR6snHmKwnNddw==",
-      "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/@inquirer/password": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-1.1.14.tgz",
-      "integrity": "sha512-vL2BFxfMo8EvuGuZYlryiyAB3XsgtbxOcFs4H9WI9szAS/VZCAwdVqs8rqEeaAf/GV/eZOghIOYxvD91IsRWSg==",
-      "dependencies": {
-        "@inquirer/input": "^1.2.14",
-        "@inquirer/type": "^1.1.5",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/@inquirer/prompts": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-3.3.0.tgz",
-      "integrity": "sha512-BBCqdSnhNs+WziSIo4f/RNDu6HAj4R/Q5nMgJb5MNPFX8sJGCvj9BoALdmR0HTWXyDS7TO8euKj6W6vtqCQG7A==",
-      "dependencies": {
-        "@inquirer/checkbox": "^1.5.0",
-        "@inquirer/confirm": "^2.0.15",
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/editor": "^1.2.13",
-        "@inquirer/expand": "^1.1.14",
-        "@inquirer/input": "^1.2.14",
-        "@inquirer/password": "^1.1.14",
-        "@inquirer/rawlist": "^1.2.14",
-        "@inquirer/select": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/@inquirer/rawlist": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-1.2.14.tgz",
-      "integrity": "sha512-xIYmDpYgfz2XGCKubSDLKEvadkIZAKbehHdWF082AyC2I4eHK44RUfXaoOAqnbqItZq4KHXS6jDJ78F2BmQvxg==",
-      "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/@inquirer/select": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.3.1.tgz",
-      "integrity": "sha512-EgOPHv7XOHEqiBwBJTyiMg9r57ySyW4oyYCumGp+pGyOaXQaLb2kTnccWI6NFd9HSi5kDJhF7YjA+3RfMQJ2JQ==",
-      "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "figures": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
     "node_modules/@inquirer/type": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.5.tgz",
-      "integrity": "sha512-wmwHvHozpPo4IZkkNtbYenem/0wnfI6hvOcGKmPEa0DwuaH5XUQzFqy6OpEpjEegZMhYIk8HDYITI16BPLtrRA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.2.1.tgz",
+      "integrity": "sha512-xwMfkPAxeo8Ji/IxfUSqzRi0/+F2GIqJmpc5/thelgMGsjNZcjDDRBO9TLXT1s/hdx/mK5QbVIvgoLIFgXhTMQ==",
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1914,9 +1797,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.2.tgz",
-      "integrity": "sha512-WHZXKFCEyIUJzAwh3NyyTHYSR35SevJ6mZ1nWwJafKtiQbqRTIKSRcw3Ma3acqgsent3RRDqeVwpHntMk+9irg==",
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2717,11 +2600,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -4583,19 +4461,6 @@
       "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
       "dev": true
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5432,17 +5297,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -7836,14 +7690,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-is-promise": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
@@ -9159,7 +9005,9 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -10334,17 +10182,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "funding": "https://dotenvx.com",
   "dependencies": {
-    "@inquirer/prompts": "^3.3.0",
+    "@inquirer/confirm": "^2.0.17",
     "arch": "^2.1.1",
     "boxen": "^5.0.0",
     "chalk": "^4.1.2",

--- a/src/cli/actions/hub/login.js
+++ b/src/cli/actions/hub/login.js
@@ -1,7 +1,7 @@
 const open = require('open')
 const { request } = require('undici')
 const clipboardy = require('./../../../lib/helpers/clipboardy')
-const { confirm } = require('@inquirer/prompts')
+const { confirm } = require('@inquirer/confirm')
 
 const createSpinner = require('./../../../shared/createSpinner')
 const store = require('./../../../shared/store')

--- a/src/cli/actions/hub/open.js
+++ b/src/cli/actions/hub/open.js
@@ -1,5 +1,5 @@
 const openBrowser = require('open')
-const { confirm } = require('@inquirer/prompts')
+const { confirm } = require('@inquirer/confirm')
 
 const createSpinner = require('./../../../shared/createSpinner')
 const logger = require('./../../../shared/logger')


### PR DESCRIPTION
dotenvx uses `@inquirer/prompts` which just exports all `@inquirer/` packages. as it only really uses the confirm function, which is just a re-export of `@inquirer/confirm`, this pr replaces usage of `@inquirer/prompts` with that