### PR TITLE
Fix import paths for @inquirer/confirm

### DIFF
--- a/src/cli/actions/hub/login.js
+++ b/src/cli/actions/hub/login.js
@@ -1,7 +1,7 @@
 const open = require('open')
 const { request } = require('undici')
 const clipboardy = require('./../../../lib/helpers/clipboardy')
-const { confirm } = require('@inquirer/confirm')
+const confirm = require('@inquirer/confirm').default
 
 const createSpinner = require('./../../../shared/createSpinner')
 const store = require('./../../../shared/store')

--- a/src/cli/actions/hub/open.js
+++ b/src/cli/actions/hub/open.js
@@ -1,5 +1,5 @@
 const openBrowser = require('open')
-const { confirm } = require('@inquirer/confirm')
+const confirm = require('@inquirer/confirm').default
 
 const createSpinner = require('./../../../shared/createSpinner')
 const logger = require('./../../../shared/logger')


### PR DESCRIPTION
I've tried this both on the brew packages, and via yarn. When I run `dotenvx hub open` or `dotenv hub login` it throws an error:

```
/snapshot/dotenvx/src/cli/actions/hub/open.js:19
  const answer = await confirm({ message: `press Enter to open [${openUrl}]...` })
                       ^

TypeError: confirm is not a function
    at Command.open (/snapshot/dotenvx/src/cli/actions/hub/open.js:19:24)
    at Command.listener [as _actionHandler] (/snapshot/dotenvx/node_modules/commander/lib/command.js:494:17)
    at /snapshot/dotenvx/node_modules/commander/lib/command.js:1296:65
    at Command._chainOrCall (/snapshot/dotenvx/node_modules/commander/lib/command.js:1193:12)
    at Command._parseCommand (/snapshot/dotenvx/node_modules/commander/lib/command.js:1296:27)
    at /snapshot/dotenvx/node_modules/commander/lib/command.js:1082:27
    at Command._chainOrCall (/snapshot/dotenvx/node_modules/commander/lib/command.js:1193:12)
    at Command._dispatchSubcommand (/snapshot/dotenvx/node_modules/commander/lib/command.js:1078:25)
    at Command._parseCommand (/snapshot/dotenvx/node_modules/commander/lib/command.js:1264:19)
    at /snapshot/dotenvx/node_modules/commander/lib/command.js:1082:27
```

Updating the imports for @inquirer/confirm fixes the problem.