### PR TITLE
remove `arch` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/confirm": "^2.0.17",
-        "arch": "^2.1.1",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "conf": "^10.2.0",
@@ -1997,25 +1996,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/arg": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "funding": "https://dotenvx.com",
   "dependencies": {
     "@inquirer/confirm": "^2.0.17",
-    "arch": "^2.1.1",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "conf": "^10.2.0",

--- a/src/lib/helpers/clipboardy/windows.js
+++ b/src/lib/helpers/clipboardy/windows.js
@@ -1,10 +1,9 @@
 'use strict'
 const path = require('path')
 const execa = require('execa')
-const arch = require('arch')
 
 // Binaries from: https://github.com/sindresorhus/clipboardy/tree/v2.3.0
-const windowBinaryPath = arch() === 'x64'
+const windowBinaryPath = process.arch === 'x64'
   ? path.join(__dirname, './fallbacks/windows/clipboard_x86_64.exe')
   : path.join(__dirname, './fallbacks/windows/clipboard_i686.exe')
 


### PR DESCRIPTION
on windows systems, it's reliable to just check process.arch
the arch package has specific checks for other systems