### PR TITLE
add support for .env.[env].local

### DIFF
--- a/src/cli/actions/decrypt.js
+++ b/src/cli/actions/decrypt.js
@@ -57,7 +57,8 @@ async function decrypt () {
       const decrypted = libDecrypt(ciphertext, value.trim())
 
       // envFilename
-      let envFilename = `.env.${environment}`
+      // replace _ with . to support filenames like .env.development.local
+      let envFilename = `.env.${environment.replace("_", ".")}`
       if (environment === 'development') {
         envFilename = '.env'
       }

--- a/src/cli/actions/decrypt.js
+++ b/src/cli/actions/decrypt.js
@@ -58,7 +58,7 @@ async function decrypt () {
 
       // envFilename
       // replace _ with . to support filenames like .env.development.local
-      let envFilename = `.env.${environment.replace("_", ".")}`
+      let envFilename = `.env.${environment.replace('_', '.')}`
       if (environment === 'development') {
         envFilename = '.env'
       }

--- a/src/lib/helpers/dotenvKeys.js
+++ b/src/lib/helpers/dotenvKeys.js
@@ -1,6 +1,8 @@
 const path = require('path')
 const crypto = require('crypto')
 
+const guessEnvironment = require("./guessEnvironment");
+
 class DotenvKeys {
   constructor (envFilepaths = [], dotenvKeys = {}) {
     this.envFilepaths = envFilepaths // pass .env* filepaths to be encrypted
@@ -12,7 +14,7 @@ class DotenvKeys {
     const existingKeys = new Set()
 
     for (const filepath of this.envFilepaths) {
-      const environment = this._guessEnvironment(filepath)
+      const environment = guessEnvironment(filepath)
       const key = `DOTENV_KEY_${environment.toUpperCase()}`
 
       let value = this.dotenvKeys[key]
@@ -44,18 +46,6 @@ class DotenvKeys {
       addedKeys: [...addedKeys], // return set as array
       existingKeys: [...existingKeys] // return set as array
     }
-  }
-
-  _guessEnvironment (filepath) {
-    const filename = path.basename(filepath)
-    const parts = filename.split('.')
-    const possibleEnvironment = parts[2] // ['', 'env', environment', 'previous']
-
-    if (!possibleEnvironment || possibleEnvironment.length === 0) {
-      return 'development'
-    }
-
-    return possibleEnvironment
   }
 
   _generateDotenvKey (environment) {

--- a/src/lib/helpers/dotenvKeys.js
+++ b/src/lib/helpers/dotenvKeys.js
@@ -1,7 +1,6 @@
-const path = require('path')
 const crypto = require('crypto')
 
-const guessEnvironment = require("./guessEnvironment");
+const guessEnvironment = require('./guessEnvironment')
 
 class DotenvKeys {
   constructor (envFilepaths = [], dotenvKeys = {}) {

--- a/src/lib/helpers/guessEnvironment.js
+++ b/src/lib/helpers/guessEnvironment.js
@@ -3,13 +3,24 @@ const path = require('path')
 function guessEnvironment (filepath) {
   const filename = path.basename(filepath)
   const parts = filename.split('.')
-  const possibleEnvironment = parts[2] // ['', 'env', environment', 'previous']
+  const possibleEnvironmentList = [...parts.slice(2)]
 
-  if (!possibleEnvironment || possibleEnvironment.length === 0) {
+  if (possibleEnvironmentList.length === 0) {
     return 'development'
   }
+  
+  if (possibleEnvironmentList.length === 1) {
+    return possibleEnvironmentList[0]
+  }
 
-  return possibleEnvironment
+  if (
+    possibleEnvironmentList.length === 2 &&
+    possibleEnvironmentList[possibleEnvironmentList.length - 1] === "local"
+  ) {
+    return possibleEnvironmentList.join("_")
+  }
+
+  return possibleEnvironmentList[0]
 }
 
 module.exports = guessEnvironment

--- a/src/lib/helpers/guessEnvironment.js
+++ b/src/lib/helpers/guessEnvironment.js
@@ -8,7 +8,7 @@ function guessEnvironment (filepath) {
   if (possibleEnvironmentList.length === 0) {
     return 'development'
   }
-  
+
   if (possibleEnvironmentList.length === 1) {
     return possibleEnvironmentList[0]
   }
@@ -16,7 +16,7 @@ function guessEnvironment (filepath) {
   if (
     possibleEnvironmentList.length === 2
   ) {
-    return possibleEnvironmentList.join("_")
+    return possibleEnvironmentList.join('_')
   }
 
   return possibleEnvironmentList.slice(0, 2).join('_')

--- a/src/lib/helpers/guessEnvironment.js
+++ b/src/lib/helpers/guessEnvironment.js
@@ -19,7 +19,7 @@ function guessEnvironment (filepath) {
     return possibleEnvironmentList.join("_")
   }
 
-  return possibleEnvironmentList.slice(0, 2).join('_');
+  return possibleEnvironmentList.slice(0, 2).join('_')
 }
 
 module.exports = guessEnvironment

--- a/src/lib/helpers/guessEnvironment.js
+++ b/src/lib/helpers/guessEnvironment.js
@@ -14,13 +14,12 @@ function guessEnvironment (filepath) {
   }
 
   if (
-    possibleEnvironmentList.length === 2 &&
-    possibleEnvironmentList[possibleEnvironmentList.length - 1] === "local"
+    possibleEnvironmentList.length === 2
   ) {
     return possibleEnvironmentList.join("_")
   }
 
-  return possibleEnvironmentList[0]
+  return possibleEnvironmentList.slice(0, 2).join('_');
 }
 
 module.exports = guessEnvironment

--- a/tests/lib/helpers/dotenvKeys.test.js
+++ b/tests/lib/helpers/dotenvKeys.test.js
@@ -53,7 +53,6 @@ DOTENV_KEY_DEVELOPMENT="dotenv://:key_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   ct.end()
 })
 
-
 t.test('#_generateDotenvKey (production)', ct => {
   const dotenvKeys = new DotenvKeys()
   const environment = 'production'

--- a/tests/lib/helpers/dotenvKeys.test.js
+++ b/tests/lib/helpers/dotenvKeys.test.js
@@ -53,25 +53,6 @@ DOTENV_KEY_DEVELOPMENT="dotenv://:key_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   ct.end()
 })
 
-t.test('#_guessEnvironment (.env)', ct => {
-  const dotenvKeys = new DotenvKeys()
-  const filepath = '.env'
-  const environment = dotenvKeys._guessEnvironment(filepath)
-
-  ct.same(environment, 'development')
-
-  ct.end()
-})
-
-t.test('#_guessEnvironment (.env.production)', ct => {
-  const dotenvKeys = new DotenvKeys()
-  const filepath = '.env.production'
-  const environment = dotenvKeys._guessEnvironment(filepath)
-
-  ct.same(environment, 'production')
-
-  ct.end()
-})
 
 t.test('#_generateDotenvKey (production)', ct => {
   const dotenvKeys = new DotenvKeys()

--- a/tests/lib/helpers/guessEnvironment.test.js
+++ b/tests/lib/helpers/guessEnvironment.test.js
@@ -21,37 +21,37 @@ t.test('#guessEnvironment (.env.production)', ct => {
 })
 
 t.test("#guessEnvironment (.env.local)", (ct) => {
-  const filepath = ".env.local";
-  const environment = guessEnvironment(filepath);
+  const filepath = ".env.local"
+  const environment = guessEnvironment(filepath)
 
-  ct.same(environment, "local");
+  ct.same(environment, "local")
 
-  ct.end();
+  ct.end()
 });
 
 t.test("#guessEnvironment (.env.development.local)", (ct) => {
-  const filepath = ".env.development.local";
-  const environment = guessEnvironment(filepath);
+  const filepath = ".env.development.local"
+  const environment = guessEnvironment(filepath)
 
-  ct.same(environment, "development_local");
+  ct.same(environment, "development_local")
 
-  ct.end();
+  ct.end()
 });
 
 t.test("#guessEnvironment (.env.development.production)", (ct) => {
-  const filepath = ".env.development.production";
-  const environment = guessEnvironment(filepath);
+  const filepath = ".env.development.production"
+  const environment = guessEnvironment(filepath)
 
-  ct.same(environment, "development_production");
+  ct.same(environment, "development_production")
 
-  ct.end();
+  ct.end()
 });
 
 t.test("#guessEnvironment (.env.some.other.thing)", (ct) => {
-  const filepath = ".env.some.other.thing";
-  const environment = guessEnvironment(filepath);
+  const filepath = ".env.some.other.thing"
+  const environment = guessEnvironment(filepath)
 
-  ct.same(environment, "some_other");
+  ct.same(environment, "some_other")
 
-  ct.end();
+  ct.end()
 });

--- a/tests/lib/helpers/guessEnvironment.test.js
+++ b/tests/lib/helpers/guessEnvironment.test.js
@@ -19,3 +19,30 @@ t.test('#guessEnvironment (.env.production)', ct => {
 
   ct.end()
 })
+
+t.test("#guessEnvironment (.env.local)", (ct) => {
+  const filepath = ".env.local";
+  const environment = guessEnvironment(filepath);
+
+  ct.same(environment, "local");
+
+  ct.end();
+});
+
+t.test("#guessEnvironment (.env.development.local)", (ct) => {
+  const filepath = ".env.development.local";
+  const environment = guessEnvironment(filepath);
+
+  ct.same(environment, "development_local");
+
+  ct.end();
+});
+
+t.test("#guessEnvironment (.env.development.production)", (ct) => {
+  const filepath = ".env.development.production";
+  const environment = guessEnvironment(filepath);
+
+  ct.same(environment, "development");
+
+  ct.end();
+});

--- a/tests/lib/helpers/guessEnvironment.test.js
+++ b/tests/lib/helpers/guessEnvironment.test.js
@@ -20,38 +20,38 @@ t.test('#guessEnvironment (.env.production)', ct => {
   ct.end()
 })
 
-t.test("#guessEnvironment (.env.local)", (ct) => {
-  const filepath = ".env.local"
+t.test('#guessEnvironment (.env.local)', (ct) => {
+  const filepath = '.env.local'
   const environment = guessEnvironment(filepath)
 
-  ct.same(environment, "local")
+  ct.same(environment, 'local')
 
   ct.end()
-});
+})
 
-t.test("#guessEnvironment (.env.development.local)", (ct) => {
-  const filepath = ".env.development.local"
+t.test('#guessEnvironment (.env.development.local)', (ct) => {
+  const filepath = '.env.development.local'
   const environment = guessEnvironment(filepath)
 
-  ct.same(environment, "development_local")
+  ct.same(environment, 'development_local')
 
   ct.end()
-});
+})
 
-t.test("#guessEnvironment (.env.development.production)", (ct) => {
-  const filepath = ".env.development.production"
+t.test('#guessEnvironment (.env.development.production)', (ct) => {
+  const filepath = '.env.development.production'
   const environment = guessEnvironment(filepath)
 
-  ct.same(environment, "development_production")
+  ct.same(environment, 'development_production')
 
   ct.end()
-});
+})
 
-t.test("#guessEnvironment (.env.some.other.thing)", (ct) => {
-  const filepath = ".env.some.other.thing"
+t.test('#guessEnvironment (.env.some.other.thing)', (ct) => {
+  const filepath = '.env.some.other.thing'
   const environment = guessEnvironment(filepath)
 
-  ct.same(environment, "some_other")
+  ct.same(environment, 'some_other')
 
   ct.end()
-});
+})

--- a/tests/lib/helpers/guessEnvironment.test.js
+++ b/tests/lib/helpers/guessEnvironment.test.js
@@ -42,7 +42,16 @@ t.test("#guessEnvironment (.env.development.production)", (ct) => {
   const filepath = ".env.development.production";
   const environment = guessEnvironment(filepath);
 
-  ct.same(environment, "development");
+  ct.same(environment, "development_production");
+
+  ct.end();
+});
+
+t.test("#guessEnvironment (.env.some.other.thing)", (ct) => {
+  const filepath = ".env.some.other.thing";
+  const environment = guessEnvironment(filepath);
+
+  ct.same(environment, "some_other");
 
   ct.end();
 });


### PR DESCRIPTION
### Introduction
This adds support for files like `.env.development.local`. [NextJS](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#default-environment-variables) uses this convention to let you add defaults for development or production envs.

I needed it for use with [Plasmo](https://docs.plasmo.com/framework/env#local-env), which has adopted the pattern from NextJS.

### Changes

If a `.env.[env].local` file is detected, the environment name is set to `[env]_local` when used for vault and keys. When decrypting the vault, if the name of the env contains a `_`, it is replaced by a `.` when the file is written to disk.

I've added tests for `guessEnvironment`.