### PR TITLE
add ignoredFiles to status command

### DIFF
--- a/src/cli/actions/status.js
+++ b/src/cli/actions/status.js
@@ -2,15 +2,16 @@ const logger = require('./../../shared/logger')
 
 const main = require('./../../lib/main')
 
-function status (directory) {
+function status(directory, { ignoredFiles } ) {
   // debug args
   logger.debug(`directory: ${directory}`)
+  logger.debug(`ignoredFiles: ${ignoredFiles?.join(', ')}`)
 
   const options = this.opts()
   logger.debug(`options: ${JSON.stringify(options)}`)
 
   try {
-    const { changes, nochanges } = main.status(directory)
+    const { changes, nochanges } = main.status(directory, ignoredFiles)
 
     const changeFilenames = []
     const nochangeFilenames = []
@@ -51,6 +52,7 @@ function status (directory) {
       logger.help('? add one with [echo "HELLO=World" > .env] and then run [dotenvx status]')
     }
   } catch (error) {
+    console.error(error.stack);
     logger.error(error.message)
     if (error.help) {
       logger.help(error.help)
@@ -61,6 +63,7 @@ function status (directory) {
     if (error.code) {
       logger.debug(`ERROR_CODE: ${error.code}`)
     }
+
     process.exit(1)
   }
 }

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -120,6 +120,7 @@ program.command('decrypt')
 program.command('status')
   .description('compare your .env* content(s) to your .env.vault decrypted content(s)')
   .argument('[directory]', 'directory to check status against', '.')
+  .option('-i, --ignoredFiles <fileName...>', 'files to ignore', [])
   .action(require('./actions/status'))
 
 // dotenvx genexample

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -62,8 +62,8 @@ const set = function (key, value, envFile) {
   return new Sets(key, value, envFile).run()
 }
 
-const status = function (directory) {
-  return new Status(directory).run()
+const status = function (directory, ignoredFiles) {
+  return new Status(directory, ignoredFiles).run()
 }
 
 const settings = function (key = null) {

--- a/src/lib/services/status.js
+++ b/src/lib/services/status.js
@@ -12,8 +12,9 @@ const guessEnvironment = require('./../helpers/guessEnvironment')
 const ENCODING = 'utf8'
 
 class Status {
-  constructor (directory = '.') {
+  constructor (directory = '.', ignoredFiles = []) {
     this.directory = directory
+    this.ignoredFiles = ['.previous','.env.keys','.env.vault','.env.example'].concat(ignoredFiles)
     this.changes = []
     this.nochanges = []
   }
@@ -28,23 +29,9 @@ class Status {
         continue
       }
 
-      // skip file if .env.keys
-      if (filename.endsWith('.env.keys')) {
-        continue
-      }
 
-      // skip file if .env.vault
-      if (filename.endsWith('.env.vault')) {
-        continue
-      }
-
-      // skip file if .env.example
-      if (filename.endsWith('.env.example')) {
-        continue
-      }
-
-      // skip file if *.previous
-      if (filename.endsWith('.previous')) {
+      // skip file if found in ignoredFiles
+      if (this.ignoredFiles.some((pattern) => filename.endsWith(pattern))) {
         continue
       }
 

--- a/tests/lib/services/status.test.js
+++ b/tests/lib/services/status.test.js
@@ -17,6 +17,23 @@ t.test('#run', ct => {
   ct.end()
 })
 
+t.test('#run (when ignoring .env.raw)', ct => {
+  try {
+    fs.writeFileSync(path.resolve('tests/monorepo/apps/backend/.env.raw'), 'SOME_KEY=1')
+    const {
+      changes,
+      nochanges
+    } = new Status('tests/monorepo/apps/backend', '.env.raw').run()
+
+    ct.same(changes, [])
+    ct.same(nochanges[0].filename, '.env')
+
+    ct.end()
+  } finally {
+    fs.unlinkSync(path.resolve('tests/monorepo/apps/backend/.env.raw'))
+  }
+})
+
 t.test('#run (when .env different than .env.vault contents)', ct => {
   const originalReadFileSync = fs.readFileSync
   const sandbox = sinon.createSandbox()


### PR DESCRIPTION
Sample PR for the feature request:

https://github.com/dotenvx/dotenvx/issues/194

In short this PR adds ability to skip files when running `dotenvx status` since in our usecase we have couple .env.X named files that are not to be encrypted in the vault.

Standard example would be `.env.local` that is not in git and therefore not encrypted, when running `dotenvx status` it gets picked up and as is does not have record in `.env.vault` the code throw TypeError when calling Diff on undefined vs string.