### PR TITLE
fix spelling mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install dotenvx/brew/dotenvx
 ```
 > * [other global ways to install](https://dotenvx.com/docs/install)
 >
-> Intall globally as a cli to unlock dotenv for ANY language, framework, or platform. 💥
+> Install globally as a cli to unlock dotenv for ANY language, framework, or platform. 💥
 >
 > I am using (and recommending) this approach going forward. – [motdotla](https://github.com/motdotla)
 


### PR DESCRIPTION
I had noticed that there was a minor spelling mistake in the README.md file:

```
Intall globally as a cli to unlock dotenv for ANY language, framework, or platform. 💥
    ^ I believe you meant to type install here.
```