### PR TITLE
Refactor `logger` util to share logger `level` configuration across CLI + JavaScript tools

### DIFF
--- a/src/cli/actions/convert.js
+++ b/src/cli/actions/convert.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 const main = require('./../../lib/main')
 

--- a/src/cli/actions/genexample.js
+++ b/src/cli/actions/genexample.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const main = require('./../../lib/main')
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 const createSpinner = require('./../../shared/createSpinner')
 
 const sleep = require('./../../lib/helpers/sleep')

--- a/src/cli/actions/get.js
+++ b/src/cli/actions/get.js
@@ -1,4 +1,4 @@
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 const conventions = require('./../../lib/helpers/conventions')
 

--- a/src/cli/actions/gitignore.js
+++ b/src/cli/actions/gitignore.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 
 const FORMATS = ['.env*', '!.env.vault']
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 class Generic {
   constructor (filename, touchFile = false) {

--- a/src/cli/actions/hub/login.js
+++ b/src/cli/actions/hub/login.js
@@ -5,7 +5,7 @@ const confirm = require('@inquirer/confirm').default
 
 const createSpinner = require('./../../../shared/createSpinner')
 const store = require('./../../../shared/store')
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 
 const OAUTH_CLIENT_ID = 'oac_dotenvxcli'
 

--- a/src/cli/actions/hub/logout.js
+++ b/src/cli/actions/hub/logout.js
@@ -3,7 +3,7 @@ const confirm = require('@inquirer/confirm').default
 
 const createSpinner = require('./../../../shared/createSpinner')
 const store = require('./../../../shared/store')
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 const sleep = require('./../../../lib/helpers/sleep')
 
 const username = store.getUsername()

--- a/src/cli/actions/hub/open.js
+++ b/src/cli/actions/hub/open.js
@@ -2,7 +2,7 @@ const openBrowser = require('open')
 const confirm = require('@inquirer/confirm').default
 
 const createSpinner = require('./../../../shared/createSpinner')
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 
 const isGitRepo = require('./../../../lib/helpers/isGitRepo')
 const isGithub = require('./../../../lib/helpers/isGithub')

--- a/src/cli/actions/hub/pull.js
+++ b/src/cli/actions/hub/pull.js
@@ -3,7 +3,7 @@ const path = require('path')
 const { request } = require('undici')
 
 const store = require('./../../../shared/store')
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 const createSpinner = require('./../../../shared/createSpinner')
 
 const isGitRepo = require('./../../../lib/helpers/isGitRepo')

--- a/src/cli/actions/hub/push.js
+++ b/src/cli/actions/hub/push.js
@@ -3,7 +3,7 @@ const path = require('path')
 const { request } = require('undici')
 
 const store = require('./../../../shared/store')
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 const createSpinner = require('./../../../shared/createSpinner')
 
 const isGitRepo = require('./../../../lib/helpers/isGitRepo')

--- a/src/cli/actions/hub/status.js
+++ b/src/cli/actions/hub/status.js
@@ -1,5 +1,5 @@
 const store = require('./../../../shared/store')
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 
 async function status () {
   logger.info(`logged in to ${store.getHostname()} as ${store.getUsername()}`)

--- a/src/cli/actions/hub/token.js
+++ b/src/cli/actions/hub/token.js
@@ -1,5 +1,5 @@
 const store = require('./../../../shared/store')
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 
 async function token () {
   logger.debug(store.configPath())

--- a/src/cli/actions/ls.js
+++ b/src/cli/actions/ls.js
@@ -1,6 +1,6 @@
 const treeify = require('object-treeify')
 
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 const main = require('./../../lib/main')
 const ArrayToTree = require('./../../lib/helpers/arrayToTree')

--- a/src/cli/actions/prebuild.js
+++ b/src/cli/actions/prebuild.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 
 const ignore = require('ignore')
 
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 const pluralize = require('./../../lib/helpers/pluralize')
 
 function prebuild () {

--- a/src/cli/actions/precommit.js
+++ b/src/cli/actions/precommit.js
@@ -1,4 +1,4 @@
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 const Precommit = require('./../../lib/services/precommit')
 

--- a/src/cli/actions/run.js
+++ b/src/cli/actions/run.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const execa = require('execa')
 const which = require('which')
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 const Run = require('./../../lib/services/run')
 

--- a/src/cli/actions/scan.js
+++ b/src/cli/actions/scan.js
@@ -1,6 +1,6 @@
 const execa = require('execa')
 
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 async function scan () {
   const options = this.opts()

--- a/src/cli/actions/set.js
+++ b/src/cli/actions/set.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 const main = require('./../../lib/main')
 

--- a/src/cli/actions/settings.js
+++ b/src/cli/actions/settings.js
@@ -1,4 +1,4 @@
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 const main = require('./../../lib/main')
 

--- a/src/cli/actions/vault/convert.js
+++ b/src/cli/actions/vault/convert.js
@@ -1,4 +1,4 @@
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 
 function convert (directory) {
   // debug args

--- a/src/cli/actions/vault/decrypt.js
+++ b/src/cli/actions/vault/decrypt.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 const createSpinner = require('./../../../shared/createSpinner')
 const sleep = require('./../../../lib/helpers/sleep')
 

--- a/src/cli/actions/vault/encrypt.js
+++ b/src/cli/actions/vault/encrypt.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 const main = require('./../../../lib/main')
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 const createSpinner = require('./../../../shared/createSpinner')
 const sleep = require('./../../../lib/helpers/sleep')
 const pluralize = require('./../../../lib/helpers/pluralize')

--- a/src/cli/actions/vault/status.js
+++ b/src/cli/actions/vault/status.js
@@ -1,4 +1,4 @@
-const logger = require('./../../../shared/logger')
+const { logger } = require('./../../../shared/logger')
 
 const main = require('./../../../lib/main')
 

--- a/src/cli/commands/hub.js
+++ b/src/cli/commands/hub.js
@@ -1,7 +1,7 @@
 const { Command } = require('commander')
 
 const store = require('./../../shared/store')
-const logger = require('./../../shared/logger')
+const { logger } = require('./../../shared/logger')
 
 const hub = new Command('hub')
 

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -4,7 +4,7 @@ const UpdateNotice = require('./../lib/helpers/updateNotice')
 const { Command } = require('commander')
 const program = new Command()
 
-const logger = require('./../shared/logger')
+const { setLogLevel, logger } = require('../shared/logger')
 const examples = require('./examples')
 const packageJson = require('./../lib/helpers/packageJson')
 
@@ -33,25 +33,7 @@ program
   .hook('preAction', (thisCommand, actionCommand) => {
     const options = thisCommand.opts()
 
-    if (options.logLevel) {
-      logger.level = options.logLevel
-      logger.debug(`setting log level to ${options.logLevel}`)
-    }
-
-    // --quiet overides --log-level. only errors will be shown
-    if (options.quiet) {
-      logger.level = 'error'
-    }
-
-    // --verbose overrides --quiet
-    if (options.verbose) {
-      logger.level = 'verbose'
-    }
-
-    // --debug overrides --verbose
-    if (options.debug) {
-      logger.level = 'debug'
-    }
+    setLogLevel(options)
   })
 
 // cli

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const logger = require('./../shared/logger')
+const { logger } = require('./../shared/logger')
 const dotenv = require('dotenv')
 
 // services
@@ -15,6 +15,7 @@ const VaultEncrypt = require('./services/vaultEncrypt')
 
 // helpers
 const dotenvOptionPaths = require('./helpers/dotenvOptionPaths')
+const { setLogLevel } = require('../shared/logger')
 
 // proxies to dotenv
 const config = function (options = {}) {
@@ -33,16 +34,7 @@ const config = function (options = {}) {
     DOTENV_KEY = options.DOTENV_KEY
   }
 
-  // --quiet CLI flag equivalent. only errors will be shown
-  if (options && options.quiet) {
-    logger.level = 'error'
-  }
-
-  // debug -> log level
-  if (options && options.debug) {
-    logger.level = 'debug'
-    logger.debug('setting log level to debug')
-  }
+  setLogLevel(options)
 
   // build envs using user set option.path
   const optionPaths = dotenvOptionPaths(options) // [ '.env' ]

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -33,6 +33,11 @@ const config = function (options = {}) {
     DOTENV_KEY = options.DOTENV_KEY
   }
 
+  // --quiet CLI flag equivalent. only errors will be shown
+  if (options && options.quiet) {
+    logger.level = 'error'
+  }
+
   // debug -> log level
   if (options && options.debug) {
     logger.level = 'debug'

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -34,7 +34,7 @@ const config = function (options = {}) {
     DOTENV_KEY = options.DOTENV_KEY
   }
 
-  setLogLevel(options)
+  if (options) setLogLevel(options)
 
   // build envs using user set option.path
   const optionPaths = dotenvOptionPaths(options) // [ '.env' ]

--- a/src/shared/logger.js
+++ b/src/shared/logger.js
@@ -104,24 +104,19 @@ const logger = createLogger({
 })
 
 const setLogLevel = options => {
-  if (options.logLevel) {
-    logger.level = options.logLevel
-    logger.debug(`setting log level to ${options.logLevel}`)
-  }
+  const logLevel = options.debug
+    ? 'debug'
+    : options.verbose
+      ? 'verbose'
+      : options.quiet
+        ? 'error'
+        : options.logLevel
 
-  // --quiet overides --log-level. only errors will be shown
-  if (options.quiet) {
-    logger.level = 'error'
-  }
-
-  // --verbose overrides --quiet
-  if (options.verbose) {
-    logger.level = 'verbose'
-  }
-
-  // --debug overrides --verbose
-  if (options.debug) {
-    logger.level = 'debug'
+  if (!logLevel) return
+  logger.level = logLevel
+  // Only log which level it's setting if it's not set to quiet mode
+  if (!options.quiet || (options.quiet && logLevel !== 'error')) {
+    logger.debug(`Setting log level to ${logLevel}`)
   }
 }
 

--- a/src/shared/logger.js
+++ b/src/shared/logger.js
@@ -103,4 +103,29 @@ const logger = createLogger({
   ]
 })
 
-module.exports = logger
+const setLogLevel = options => {
+  if (options.logLevel) {
+    logger.level = options.logLevel
+    logger.debug(`setting log level to ${options.logLevel}`)
+  }
+
+  // --quiet overides --log-level. only errors will be shown
+  if (options.quiet) {
+    logger.level = 'error'
+  }
+
+  // --verbose overrides --quiet
+  if (options.verbose) {
+    logger.level = 'verbose'
+  }
+
+  // --debug overrides --verbose
+  if (options.debug) {
+    logger.level = 'debug'
+  }
+}
+
+module.exports = {
+  logger,
+  setLogLevel
+}

--- a/tests/lib/config-vault.test.js
+++ b/tests/lib/config-vault.test.js
@@ -4,7 +4,7 @@ const sinon = require('sinon')
 const t = require('tap')
 
 const dotenvx = require('../../src/lib/main')
-const logger = require('../../src/shared/logger')
+const { logger } = require('../../src/shared/logger')
 
 const testPath = 'tests/.env'
 

--- a/tests/lib/config.test.js
+++ b/tests/lib/config.test.js
@@ -217,3 +217,15 @@ t.test('logs when in debug mode', ct => {
 
   logStub.restore()
 })
+
+t.test('does not log when in quiet mode', ct => {
+  ct.plan(1)
+
+  const logStub = sinon.stub(logger, 'debug')
+
+  dotenvx.config({ quiet: true })
+
+  ct.notOk(logStub.called)
+
+  logStub.restore()
+})

--- a/tests/lib/config.test.js
+++ b/tests/lib/config.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon')
 const t = require('tap')
 
 const dotenvx = require('../../src/lib/main')
-const logger = require('../../src/shared/logger')
+const { logger } = require('../../src/shared/logger')
 
 t.beforeEach((ct) => {
   // important, clear process.env before each test
@@ -209,23 +209,75 @@ t.test('logs any errors thrown from reading file or parsing when in debug mode',
 t.test('logs when in debug mode', ct => {
   ct.plan(1)
 
-  const logStub = sinon.stub(logger, 'debug')
+  dotenvx.config({ debug: true })
 
-  dotenvx.config({ debug: true, override: true })
-
-  ct.ok(logStub.called)
-
-  logStub.restore()
+  ct.equal(logger.level, 'debug')
 })
 
 t.test('does not log when in quiet mode', ct => {
-  ct.plan(1)
+  ct.plan(2)
 
   const logStub = sinon.stub(logger, 'debug')
 
   dotenvx.config({ quiet: true })
 
+  ct.equal(logger.level, 'error')
   ct.notOk(logStub.called)
+
+  logStub.restore()
+})
+
+t.test('logs in verbose mode', ct => {
+  ct.plan(1)
+
+  dotenvx.config({ verbose: true })
+
+  ct.equal(logger.level, 'verbose')
+})
+
+t.test('sets specific log level and logs it', ct => {
+  ct.plan(2)
+
+  const logStub = sinon.stub(logger, 'debug')
+
+  dotenvx.config({ logLevel: 'warn' })
+
+  ct.equal(logger.level, 'warn')
+  ct.ok(logStub.calledWith('setting log level to warn'))
+
+  logStub.restore()
+})
+
+t.test('verbose mode overrides quiet mode', ct => {
+  ct.plan(1)
+
+  dotenvx.config({ quiet: true, verbose: true })
+
+  ct.equal(logger.level, 'verbose')
+})
+
+t.test('quiet mode overrides specific log level', ct => {
+  ct.plan(2)
+
+  const logStub = sinon.stub(logger, 'debug')
+
+  dotenvx.config({ logLevel: 'warn', quiet: true })
+
+  ct.equal(logger.level, 'error')
+  ct.ok(logStub.calledWith('setting log level to warn'))
+
+  logStub.restore()
+})
+
+t.test('debug mode overrides logLevel, quiet, verbose', ct => {
+  ct.plan(2)
+
+  const logStub = sinon.stub(logger, 'debug')
+
+  dotenvx.config({ logLevel: 'warn', debug: true, quiet: true, verbose: true })
+
+  ct.equal(logger.level, 'debug')
+  ct.ok(logStub.calledWith('setting log level to warn'))
 
   logStub.restore()
 })

--- a/tests/lib/config.test.js
+++ b/tests/lib/config.test.js
@@ -207,14 +207,18 @@ t.test('logs any errors thrown from reading file or parsing when in debug mode',
 })
 
 t.test('logs when in debug mode', ct => {
-  ct.plan(1)
+  ct.plan(2)
+  const logStub = sinon.stub(logger, 'debug')
 
   dotenvx.config({ debug: true })
 
   ct.equal(logger.level, 'debug')
+  ct.ok(logStub.calledWith('Setting log level to debug'))
+
+  logStub.restore()
 })
 
-t.test('does not log when in quiet mode', ct => {
+t.test('logs only errors in quiet mode', ct => {
   ct.plan(2)
 
   const logStub = sinon.stub(logger, 'debug')
@@ -228,11 +232,16 @@ t.test('does not log when in quiet mode', ct => {
 })
 
 t.test('logs in verbose mode', ct => {
-  ct.plan(1)
+  ct.plan(2)
+
+  const logStub = sinon.stub(logger, 'debug')
 
   dotenvx.config({ verbose: true })
 
   ct.equal(logger.level, 'verbose')
+  ct.ok(logStub.calledWith('Setting log level to verbose'))
+
+  logStub.restore()
 })
 
 t.test('sets specific log level and logs it', ct => {
@@ -243,17 +252,22 @@ t.test('sets specific log level and logs it', ct => {
   dotenvx.config({ logLevel: 'warn' })
 
   ct.equal(logger.level, 'warn')
-  ct.ok(logStub.calledWith('setting log level to warn'))
+  ct.ok(logStub.calledWith('Setting log level to warn'))
 
   logStub.restore()
 })
 
 t.test('verbose mode overrides quiet mode', ct => {
-  ct.plan(1)
+  ct.plan(2)
+
+  const logStub = sinon.stub(logger, 'debug')
 
   dotenvx.config({ quiet: true, verbose: true })
 
   ct.equal(logger.level, 'verbose')
+  ct.ok(logStub.calledWith('Setting log level to verbose'))
+
+  logStub.restore()
 })
 
 t.test('quiet mode overrides specific log level', ct => {
@@ -264,7 +278,7 @@ t.test('quiet mode overrides specific log level', ct => {
   dotenvx.config({ logLevel: 'warn', quiet: true })
 
   ct.equal(logger.level, 'error')
-  ct.ok(logStub.calledWith('setting log level to warn'))
+  ct.notOk(logStub.called)
 
   logStub.restore()
 })
@@ -277,7 +291,7 @@ t.test('debug mode overrides logLevel, quiet, verbose', ct => {
   dotenvx.config({ logLevel: 'warn', debug: true, quiet: true, verbose: true })
 
   ct.equal(logger.level, 'debug')
-  ct.ok(logStub.calledWith('setting log level to warn'))
+  ct.ok(logStub.calledWith('Setting log level to debug'))
 
   logStub.restore()
 })

--- a/tests/shared/logger.test.js
+++ b/tests/shared/logger.test.js
@@ -3,7 +3,7 @@ const t = require('tap')
 const chalk = require('chalk')
 
 const packageJson = require('../../src/lib/helpers/packageJson')
-const logger = require('../../src/shared/logger')
+const { logger } = require('../../src/shared/logger')
 
 t.test('logger.blank', (ct) => {
   const message = 'message1'


### PR DESCRIPTION
# Description
This pull request refactors the `logger` util to export a new `setLogLevel` method which has the same logic as the log level setting in the CLI portion. The same override logic is present and can be maintained across either the CLI or the programmatic version of the library's initial config.

### Changes Made:
* Extracted log level setting logic from `dotenvx.js` into a new `setLogLevel` method in `logger.js`
* Slight readability refactor from multiple `if` statements to a ternary expression with the `Setting log level to...` log triggering for all settings except `quiet`
* Added unit tests to cover all new combinations

### Example Usage:
```javascript
dotenvx.config({
  quiet: true,
  verbose: true,
  debug: true,
  logLevel: "warn"
});
```

### Rationale
The CLI and programmatic configs should respect the same log level flags and override logic, this makes it easier to maintain and debug in the future.