### PR TITLE
add `--key` option to `encrypt`

### DIFF
--- a/src/cli/actions/encrypt.js
+++ b/src/cli/actions/encrypt.js
@@ -16,7 +16,7 @@ async function encrypt () {
       processedEnvFiles,
       changedFilepaths,
       unchangedFilepaths
-    } = main.encrypt(options.envFile)
+    } = main.encrypt(options.envFile, options.key)
 
     for (const processedEnvFile of processedEnvFiles) {
       logger.verbose(`encrypting ${processedEnvFile.envFilepath} (${processedEnvFile.filepath})`)

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -94,6 +94,7 @@ const encryptAction = require('./actions/encrypt')
 program.command('encrypt')
   .description('convert .env file(s) to encrypted .env file(s)')
   .option('-f, --env-file <paths...>', 'path(s) to your env file(s)')
+  .option('-k, --key <keys...>', 'keys(s) to encrypt (default: all keys in file)')
   .action(encryptAction)
 
 // dotenvx pro

--- a/src/lib/main.d.ts
+++ b/src/lib/main.d.ts
@@ -144,8 +144,9 @@ export type EncryptOutput = {
  *
  * @see https://dotenvx.com/docs
  * @param envFile - path to the .env file
+ * @param key - keys(s) to encrypt (default: all keys in .env file)
  */
-export function encrypt(envFile: string): EncryptOutput;
+export function encrypt(envFile: string, key: string): EncryptOutput;
 
 export type VaultEncryptOutput = {
   dotenvKeys: Record<string, string>;
@@ -157,6 +158,7 @@ export type VaultEncryptOutput = {
   existingVaults: string[];
   addedDotenvFilenames: string[];
   envFile: string | string[];
+  key: string | string[];
 };
 
 /**

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -194,8 +194,8 @@ const set = function (key, value, envFile, encrypt) {
 }
 
 /** @type {import('./main').encrypt} */
-const encrypt = function (envFile) {
-  return new Encrypt(envFile).run()
+const encrypt = function (envFile, key) {
+  return new Encrypt(envFile, key).run()
 }
 
 /** @type {import('./main').status} */

--- a/tests/lib/services/encrypt.test.js
+++ b/tests/lib/services/encrypt.test.js
@@ -188,3 +188,51 @@ t.test('#run (finds .env file as array)', ct => {
 
   ct.end()
 })
+
+t.test('#run (finds .env file with specified key)', ct => {
+  const envFile = 'tests/monorepo/apps/multiple/.env'
+  const {
+    processedEnvFiles,
+    changedFilepaths,
+    unchangedFilepaths
+  } = new Encrypt(envFile, ['HELLO2']).run()
+
+  const p1 = processedEnvFiles[0]
+  ct.same(p1.keys, ['HELLO2'])
+  ct.same(p1.envFilepath, 'tests/monorepo/apps/multiple/.env')
+  ct.same(changedFilepaths, ['tests/monorepo/apps/multiple/.env'])
+  ct.same(unchangedFilepaths, [])
+
+  const parsed = dotenv.parse(p1.envSrc)
+
+  ct.same(Object.keys(parsed), ['DOTENV_PUBLIC_KEY', 'HELLO', 'HELLO2', 'HELLO3'])
+  ct.ok(parsed.DOTENV_PUBLIC_KEY, 'DOTENV_PUBLIC_KEY should not be empty')
+  ct.match(parsed.HELLO, 'one', 'HELLO should not be encrypted')
+  ct.match(parsed.HELLO2, /^encrypted:/, 'HELLO should start with "encrypted:"')
+
+  ct.end()
+})
+
+t.test('#run (finds .env file with specified key as string)', ct => {
+  const envFile = 'tests/monorepo/apps/multiple/.env'
+  const {
+    processedEnvFiles,
+    changedFilepaths,
+    unchangedFilepaths
+  } = new Encrypt(envFile, 'HELLO2').run()
+
+  const p1 = processedEnvFiles[0]
+  ct.same(p1.keys, ['HELLO2'])
+  ct.same(p1.envFilepath, 'tests/monorepo/apps/multiple/.env')
+  ct.same(changedFilepaths, ['tests/monorepo/apps/multiple/.env'])
+  ct.same(unchangedFilepaths, [])
+
+  const parsed = dotenv.parse(p1.envSrc)
+
+  ct.same(Object.keys(parsed), ['DOTENV_PUBLIC_KEY', 'HELLO', 'HELLO2', 'HELLO3'])
+  ct.ok(parsed.DOTENV_PUBLIC_KEY, 'DOTENV_PUBLIC_KEY should not be empty')
+  ct.match(parsed.HELLO, 'one', 'HELLO should not be encrypted')
+  ct.match(parsed.HELLO2, /^encrypted:/, 'HELLO should start with "encrypted:"')
+
+  ct.end()
+})

--- a/tests/lib/services/ls.test.js
+++ b/tests/lib/services/ls.test.js
@@ -24,6 +24,7 @@ t.test('#run', ct => {
     'monorepo/apps/encrypted/.env.keys',
     'monorepo/apps/frontend/.env',
     'monorepo/apps/multiline/.env',
+    'monorepo/apps/multiple/.env',
     'monorepo/apps/unencrypted/.env'
   ]
 
@@ -48,6 +49,7 @@ t.test('#run (with directory argument)', ct => {
     'apps/encrypted/.env.keys',
     'apps/frontend/.env',
     'apps/multiline/.env',
+    'apps/multiple/.env',
     'apps/unencrypted/.env'
   ]
 
@@ -72,6 +74,7 @@ t.test('#run (with somehow malformed directory argument)', ct => {
     'apps/encrypted/.env.keys',
     'apps/frontend/.env',
     'apps/multiline/.env',
+    'apps/multiple/.env',
     'apps/unencrypted/.env'
   ]
 
@@ -102,6 +105,7 @@ t.test('#_filepaths', ct => {
     'monorepo/apps/encrypted/.env.keys',
     'monorepo/apps/frontend/.env',
     'monorepo/apps/multiline/.env',
+    'monorepo/apps/multiple/.env',
     'monorepo/apps/unencrypted/.env'
   ]
 

--- a/tests/monorepo/apps/multiple/.env
+++ b/tests/monorepo/apps/multiple/.env
@@ -1,0 +1,3 @@
+HELLO="one"
+HELLO2="two"
+HELLO3="three"


### PR DESCRIPTION
`dotenvx encrypt --key HELLO -k HELLO2`

will only encrypt those two keys for a given `.env` file like this:

```
# .env
HELLO="World"
HELLO2="Country"
HELLO3="town"
```