### PR TITLE
make `patch-package` only run locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@dotenvx/dotenvx",
       "version": "1.3.0",
-      "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@inquirer/confirm": "^2.0.17",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "testshell": "bash shellspec",
     "prerelease": "npm test && npm run testshell",
     "release": "standard-version",
-    "postinstall": "patch-package"
+    "prepare": "patch-package"
   },
   "funding": "https://dotenvx.com",
   "dependencies": {


### PR DESCRIPTION
fixes #282 by calling `patch-package` on `prepare` instead, which only runs when locally installing (never on the end user's machine) and on npm publish