### PR TITLE
replace `@inquirer/confirm` and `ora`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@inquirer/confirm": "^2.0.17",
+        "@clack/core": "^0.3.4",
         "arch": "^2.1.1",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
@@ -339,6 +339,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@clack/core": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.3.4.tgz",
+      "integrity": "sha512-H4hxZDXgHtWTwV3RAVenqcC4VbJZNegbBjlPvzOzCouXtS2y3sDvlO3IsbrPNWuLWPPlYVYPghQdSF64683Ldw==",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -483,75 +492,6 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.17.tgz",
-      "integrity": "sha512-EqzhGryzmGpy2aJf6LxJVhndxYmFs+m8cxXzf8nejb1DE3sabf6mUgBcp4J0jAUEiAcYzqmkqRr7LPFh/WdnXA==",
-      "dependencies": {
-        "@inquirer/core": "^6.0.0",
-        "@inquirer/type": "^1.1.6",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/@inquirer/confirm/node_modules/@inquirer/core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
-      "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
-      "dependencies": {
-        "@inquirer/type": "^1.1.6",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^20.10.7",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "cli-spinners": "^2.9.2",
-        "cli-width": "^4.1.0",
-        "figures": "^3.2.0",
-        "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/@inquirer/confirm/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@inquirer/confirm/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.2.1.tgz",
-      "integrity": "sha512-xwMfkPAxeo8Ji/IxfUSqzRi0/+F2GIqJmpc5/thelgMGsjNZcjDDRBO9TLXT1s/hdx/mK5QbVIvgoLIFgXhTMQ==",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1826,18 +1766,12 @@
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true
     },
-    "node_modules/@types/mute-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.11.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
       "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1852,11 +1786,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
@@ -1993,31 +1922,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -2814,14 +2718,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -3688,7 +3584,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/enabled": {
       "version": "2.0.0",
@@ -4489,6 +4386,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -4503,6 +4401,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -5826,6 +5725,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7168,14 +7068,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -7965,6 +7857,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "3.0.1",
@@ -9012,14 +8909,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9307,6 +9196,11 @@
       "dependencies": {
         "type-detect": "4.0.8"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -9760,6 +9654,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10586,7 +10481,9 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "is-wsl": "^2.1.1",
         "object-treeify": "1.1.33",
         "open": "^8.4.2",
-        "ora": "^5.4.1",
         "picomatch": "^3.0.1",
         "semver": "^7.3.4",
         "undici": "^5.28.3",
@@ -1927,6 +1926,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2231,6 +2231,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2259,6 +2260,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -2269,6 +2271,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2304,6 +2307,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2592,28 +2596,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-truncate": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
@@ -2729,14 +2711,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/code-excerpt": {
@@ -3351,17 +3325,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.1",
@@ -5159,6 +5122,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5757,14 +5721,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
@@ -5972,17 +5928,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-upper-case": {
@@ -6421,21 +6366,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/logform": {
       "version": "2.6.0",
@@ -7528,28 +7458,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/os-tmpdir": {
@@ -8843,18 +8751,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -9755,6 +9651,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10596,14 +10493,6 @@
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
       "integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==",
       "dev": true
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "funding": "https://dotenvx.com",
   "dependencies": {
-    "@inquirer/confirm": "^2.0.17",
+    "@clack/core": "^0.3.4",
     "arch": "^2.1.1",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "is-wsl": "^2.1.1",
     "object-treeify": "1.1.33",
     "open": "^8.4.2",
-    "ora": "^5.4.1",
     "picomatch": "^3.0.1",
     "semver": "^7.3.4",
     "undici": "^5.28.3",

--- a/src/cli/actions/ext/genexample.js
+++ b/src/cli/actions/ext/genexample.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const main = require('./../../../lib/main')
 const { logger } = require('./../../../shared/logger')
-const createSpinner = require('./../../../shared/createSpinner')
+const { createSpinner } = require('./../../../shared/createSpinner')
 
 const sleep = require('./../../../lib/helpers/sleep')
 

--- a/src/cli/actions/ext/hub/login.js
+++ b/src/cli/actions/ext/hub/login.js
@@ -1,8 +1,8 @@
 const open = require('open')
 const { request } = require('undici')
 const clipboardy = require('./../../../../lib/helpers/clipboardy')
-const confirm = require('@inquirer/confirm').default
 
+const confirm = require('./../../../../shared/confirm')
 const createSpinner = require('./../../../../shared/createSpinner')
 const store = require('./../../../../shared/store')
 const { logger } = require('./../../../../shared/logger')

--- a/src/cli/actions/ext/hub/login.js
+++ b/src/cli/actions/ext/hub/login.js
@@ -3,7 +3,7 @@ const { request } = require('undici')
 const clipboardy = require('./../../../../lib/helpers/clipboardy')
 
 const confirm = require('./../../../../shared/confirm')
-const createSpinner = require('./../../../../shared/createSpinner')
+const { createSpinner } = require('./../../../../shared/createSpinner')
 const store = require('./../../../../shared/store')
 const { logger } = require('./../../../../shared/logger')
 

--- a/src/cli/actions/ext/hub/logout.js
+++ b/src/cli/actions/ext/hub/logout.js
@@ -1,6 +1,6 @@
 const openBrowser = require('open')
-const confirm = require('@inquirer/confirm').default
 
+const confirm = require('./../../../../shared/confirm')
 const createSpinner = require('./../../../../shared/createSpinner')
 const store = require('./../../../../shared/store')
 const { logger } = require('./../../../../shared/logger')

--- a/src/cli/actions/ext/hub/logout.js
+++ b/src/cli/actions/ext/hub/logout.js
@@ -1,7 +1,7 @@
 const openBrowser = require('open')
 
 const confirm = require('./../../../../shared/confirm')
-const createSpinner = require('./../../../../shared/createSpinner')
+const { createSpinner } = require('./../../../../shared/createSpinner')
 const store = require('./../../../../shared/store')
 const { logger } = require('./../../../../shared/logger')
 const sleep = require('./../../../../lib/helpers/sleep')

--- a/src/cli/actions/ext/hub/open.js
+++ b/src/cli/actions/ext/hub/open.js
@@ -1,6 +1,6 @@
 const openBrowser = require('open')
-const confirm = require('@inquirer/confirm').default
 
+const confirm = require('./../../../../shared/confirm')
 const createSpinner = require('./../../../../shared/createSpinner')
 const { logger } = require('./../../../../shared/logger')
 

--- a/src/cli/actions/ext/hub/open.js
+++ b/src/cli/actions/ext/hub/open.js
@@ -1,7 +1,7 @@
 const openBrowser = require('open')
 
 const confirm = require('./../../../../shared/confirm')
-const createSpinner = require('./../../../../shared/createSpinner')
+const { createSpinner } = require('./../../../../shared/createSpinner')
 const { logger } = require('./../../../../shared/logger')
 
 const isGitRepo = require('./../../../../lib/helpers/isGitRepo')

--- a/src/cli/actions/ext/hub/pull.js
+++ b/src/cli/actions/ext/hub/pull.js
@@ -4,7 +4,7 @@ const { request } = require('undici')
 
 const store = require('./../../../../shared/store')
 const { logger } = require('./../../../../shared/logger')
-const createSpinner = require('./../../../../shared/createSpinner')
+const { createSpinner } = require('./../../../../shared/createSpinner')
 
 const isGitRepo = require('./../../../../lib/helpers/isGitRepo')
 const isGithub = require('./../../../../lib/helpers/isGithub')

--- a/src/cli/actions/ext/hub/push.js
+++ b/src/cli/actions/ext/hub/push.js
@@ -4,7 +4,7 @@ const { request } = require('undici')
 
 const store = require('./../../../../shared/store')
 const { logger } = require('./../../../../shared/logger')
-const createSpinner = require('./../../../../shared/createSpinner')
+const { createSpinner } = require('./../../../../shared/createSpinner')
 
 const isGitRepo = require('./../../../../lib/helpers/isGitRepo')
 const isGithub = require('./../../../../lib/helpers/isGithub')

--- a/src/cli/actions/ext/vault/decrypt.js
+++ b/src/cli/actions/ext/vault/decrypt.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 
 const { logger } = require('./../../../../shared/logger')
-const createSpinner = require('./../../../../shared/createSpinner')
+const { createSpinner } = require('./../../../../shared/createSpinner')
 const sleep = require('./../../../../lib/helpers/sleep')
 
 const Decrypt = require('./../../../../lib/services/decrypt')

--- a/src/cli/actions/ext/vault/encrypt.js
+++ b/src/cli/actions/ext/vault/encrypt.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 const main = require('./../../../../lib/main')
 const { logger } = require('./../../../../shared/logger')
-const createSpinner = require('./../../../../shared/createSpinner')
+const { createSpinner } = require('./../../../../shared/createSpinner')
 const sleep = require('./../../../../lib/helpers/sleep')
 const pluralize = require('./../../../../lib/helpers/pluralize')
 

--- a/src/shared/confirm.js
+++ b/src/shared/confirm.js
@@ -1,12 +1,12 @@
-const { ConfirmPrompt } = require('@clack/core');
+const { ConfirmPrompt } = require('@clack/core')
 
 module.exports = (opts) => {
   return new ConfirmPrompt({
-  active: 'Y',
-  inactive: 'N',
-  initialValue: true,
-  render() {
-    return `${opts.message} (${this.value ? 'Y/n' : 'y/N'})`
-  }
+    active: 'Y',
+    inactive: 'N',
+    initialValue: true,
+    render () {
+      return `${opts.message} (${this.value ? 'Y/n' : 'y/N'})`
+    }
   }).prompt()
 }

--- a/src/shared/confirm.js
+++ b/src/shared/confirm.js
@@ -1,0 +1,12 @@
+const { ConfirmPrompt } = require('@clack/core');
+
+module.exports = (opts) => {
+  return new ConfirmPrompt({
+  active: 'Y',
+  inactive: 'N',
+  initialValue: true,
+  render() {
+    return `${opts.message} (${this.value ? 'Y/n' : 'y/N'})`
+  }
+  }).prompt()
+}

--- a/src/shared/createSpinner.js
+++ b/src/shared/createSpinner.js
@@ -1,8 +1,88 @@
-const ora = require('ora')
 const chalk = require('chalk')
 
-const createSpinner = function (initialMessage = '') {
-  const spinner = ora(initialMessage)
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+const HIDE_CURSOR = '\u001B[?25l'
+const SHOW_CURSOR = '\u001B[?25h'
+const CLEAR_LINE = '\r\x1b[K'
+const SYMBOL_INFO = 'ℹ'
+const SYMBOL_WARN = '⚠'
+const SYMBOL_ERROR = '✖'
+const SYMBOL_SUCCESS = '✔'
+
+class Spinner {
+  text
+  interval
+  frameIndex = 0
+  symbol = chalk.blue(FRAMES[0])
+
+  constructor (text) {
+    this.text = text
+  }
+
+  start (text) {
+    if (text) {
+      this.text = text
+    }
+    this.render()
+    this.interval = setInterval(() => this.tick(), 50)
+  }
+
+  tick () {
+    this.symbol = chalk.blue(FRAMES[this.frameIndex++])
+    if (this.frameIndex === FRAMES.length - 1) this.frameIndex = 0
+    this.render()
+  }
+
+  render () {
+    process.stdout.write(CLEAR_LINE + HIDE_CURSOR + (this.symbol ? this.symbol + ' ' : '') + this.text)
+  }
+
+  succeed (text) {
+    if (text) {
+      this.text = text
+    }
+    this.symbol = chalk.green(SYMBOL_SUCCESS)
+    this.end()
+  }
+
+  info (text) {
+    if (text) {
+      this.text = text
+    }
+    this.symbol = chalk.blue(SYMBOL_INFO)
+    this.end()
+  }
+
+  warn (text) {
+    if (text) {
+      this.text = text
+    }
+    this.symbol = chalk.yellow(SYMBOL_WARN)
+    this.end()
+  }
+
+  fail (text) {
+    if (text) {
+      this.text = text
+    }
+    this.symbol = chalk.red(SYMBOL_ERROR)
+    this.end()
+  }
+
+  stop () {
+    this.symbol = ''
+    this.end()
+  }
+
+  end () {
+    this.render()
+    clearInterval(this.interval)
+    process.stdout.write(SHOW_CURSOR + '\n')
+  }
+}
+
+const createSpinner = (initialMessage = '') => {
+  const spinner = new Spinner(initialMessage)
 
   return {
     start: (message) => spinner.start(message),
@@ -14,4 +94,4 @@ const createSpinner = function (initialMessage = '') {
   }
 }
 
-module.exports = createSpinner
+module.exports = { createSpinner, Spinner }

--- a/tests/shared/createSpinner.test.js
+++ b/tests/shared/createSpinner.test.js
@@ -1,7 +1,86 @@
 const capcon = require('capture-console')
+const chalk = require('chalk')
 const t = require('tap')
 
-const createSpinner = require('../../src/shared/createSpinner')
+const { createSpinner, Spinner } = require('../../src/shared/createSpinner')
+
+const HIDE_CURSOR = '\u001B[?25l'
+const SHOW_CURSOR = '\u001B[?25h'
+const CLEAR_LINE = '\r\x1b[K'
+
+t.test('spinnerClass.end', (ct) => {
+  const spinner = new Spinner('encrypting')
+
+  const stdout = capcon.interceptStdout(() => {
+    spinner.end()
+  })
+
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + chalk.blue('⠋') + ' encrypting' + SHOW_CURSOR + '\n')
+
+  ct.end()
+})
+
+t.test('spinnerClass.tick', (ct) => {
+  const spinner = new Spinner('encrypting')
+
+  const stdout = capcon.interceptStdout(() => {
+    spinner.tick()
+  })
+
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + chalk.blue('⠋') + ' encrypting')
+
+  ct.end()
+})
+
+t.test('spinnerClass.tick frame 10', (ct) => {
+  const spinner = new Spinner('encrypting')
+
+  const stdout = capcon.interceptStdout(() => {
+    spinner.frameIndex = 8
+    spinner.tick()
+  })
+
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + chalk.blue('⠇') + ' encrypting')
+
+  ct.end()
+})
+
+t.test('spinnerClass.stop', (ct) => {
+  const spinner = new Spinner('encrypting')
+
+  const stdout = capcon.interceptStdout(() => {
+    spinner.stop()
+  })
+
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + 'encrypting' + SHOW_CURSOR + '\n')
+
+  ct.end()
+})
+
+t.test('spinner.done', (ct) => {
+  const spinner = createSpinner('encrypting')
+
+  const stdout = capcon.interceptStdout(() => {
+    spinner.start('message1')
+    spinner.done()
+  })
+
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + chalk.blue('⠋') + ' message1' + CLEAR_LINE + HIDE_CURSOR + chalk.green('✔') + ' message1' + SHOW_CURSOR + '\n')
+  ct.end()
+})
+
+t.test('spinner.succeed', (ct) => {
+  const spinner = createSpinner('encrypting')
+  const message = 'message1'
+
+  const stdout = capcon.interceptStdout(() => {
+    spinner.succeed(message)
+  })
+
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + `${chalk.green('✔')} ${chalk.keyword('green')('message1')}` + SHOW_CURSOR + '\n')
+
+  ct.end()
+})
 
 t.test('spinner.warn', (ct) => {
   const spinner = createSpinner('encrypting')
@@ -11,7 +90,20 @@ t.test('spinner.warn', (ct) => {
     spinner.warn(message)
   })
 
-  ct.equal(stdout, '')
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + `${chalk.yellow('⚠')} ${chalk.keyword('orangered')('message1')}` + SHOW_CURSOR + '\n')
+
+  ct.end()
+})
+
+t.test('spinner.fail', (ct) => {
+  const spinner = createSpinner('encrypting')
+  const message = 'message1'
+
+  const stdout = capcon.interceptStdout(() => {
+    spinner.fail(message)
+  })
+
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + `${chalk.red('✖')} ${chalk.bold.red('message1')}` + SHOW_CURSOR + '\n')
 
   ct.end()
 })
@@ -24,7 +116,7 @@ t.test('spinner.info', (ct) => {
     spinner.info(message)
   })
 
-  ct.equal(stdout, '')
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + `${chalk.blue('ℹ')} ${chalk.keyword('blue')('message1')}` + SHOW_CURSOR + '\n')
 
   ct.end()
 })
@@ -37,7 +129,7 @@ t.test('spinner.info (undefined)', (ct) => {
     spinner.info(message)
   })
 
-  ct.equal(stdout, '')
+  ct.equal(stdout, CLEAR_LINE + HIDE_CURSOR + `${chalk.blue('ℹ')} ${chalk.keyword('blue')('message1')}` + SHOW_CURSOR + '\n')
 
   ct.end()
 })


### PR DESCRIPTION
- Replaces `@inquirer/confirm` ([27](https://npmgraph.js.org/?q=@inquirer/confirm@2) subdependencies) with `@clack/core` ([2](https://npmgraph.js.org/?q=%40clack%2Fcore))
- Replaces `ora` ([29](https://npmgraph.js.org/?q=ora@5.4.1) subdependencies) with a native alternative (0) based on logic provided by @PondWader

As such, this PR makes the total number of dependencies used by dotenvx go from [131](https://npmgraph.js.org/?q=@dotenvx/dotenvx@1.3.0) to just [99](https://npmgraph.js.org/?q=https%3A%2F%2Fraw.githubusercontent.com%2FSuperchupuDev%2Fdotenvx%2F08e88905aa3c21487fba953348e91672ff9243c5%2Fpackage.json) :O

Before:
![image](https://github.com/dotenvx/dotenvx/assets/53496941/e32ebe72-dfcc-492d-b0f2-c71ca42a9e39)

After:
![image](https://github.com/dotenvx/dotenvx/assets/53496941/d7a70f1d-ac52-4a1f-a4cf-23f7910004f9)
