### PR TITLE
`--stdout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased](https://github.com/dotenvx/dotenvx/compare/v1.5.0...main)
 
+### Added
+
+* add `dotenvx decrypt` command. works inversely to `dotenvx encrypt`. same falgs. ([#294](https://github.com/dotenvx/dotenvx/pull/294))
+* add `--stdout` option to `dotenvx decrypt`. example: `dotenvx decrypt -f .env.production > somefile.txt`
+
 ## 1.5.0
 
 ### Added

--- a/src/cli/actions/decrypt.js
+++ b/src/cli/actions/decrypt.js
@@ -18,6 +18,7 @@ async function decrypt () {
     for (const processedEnvFile of processedEnvFiles) {
       process.stdout.write(processedEnvFile.envSrc)
     }
+    process.exit(0) // exit early
   }
 
   try {

--- a/src/cli/actions/encrypt.js
+++ b/src/cli/actions/encrypt.js
@@ -11,6 +11,18 @@ async function encrypt () {
   const options = this.opts()
   logger.debug(`options: ${JSON.stringify(options)}`)
 
+  // stdout - should not have a try so that exit codes can surface to stdout
+  if (options.stdout) {
+    const {
+      processedEnvFiles
+    } = main.encrypt(options.envFile, options.key)
+
+    for (const processedEnvFile of processedEnvFiles) {
+      process.stdout.write(processedEnvFile.envSrc)
+    }
+    process.exit(0) // exit early
+  }
+
   try {
     const {
       processedEnvFiles,

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -90,6 +90,7 @@ program.command('encrypt')
   .description('convert .env file(s) to encrypted .env file(s)')
   .option('-f, --env-file <paths...>', 'path(s) to your env file(s)')
   .option('-k, --key <keys...>', 'keys(s) to encrypt (default: all keys in file)')
+  .option('--stdout', 'send to stdout')
   .action(encryptAction)
 
 // dotenvx decrypt

--- a/src/lib/helpers/findOrCreatePublicKey.js
+++ b/src/lib/helpers/findOrCreatePublicKey.js
@@ -24,6 +24,7 @@ function findOrCreatePublicKey (envFilepath, envKeysFilepath) {
   // parsed
   const envParsed = dotenv.parse(envSrc)
   const keysParsed = dotenv.parse(keysSrc)
+  const existingPrivateKey = keysParsed[privateKeyName]
 
   // if DOTENV_PUBLIC_KEY_${environment} already present then go no further
   if (envParsed[publicKeyName] && envParsed[publicKeyName].length > 0) {
@@ -31,13 +32,13 @@ function findOrCreatePublicKey (envFilepath, envKeysFilepath) {
       envSrc,
       keysSrc,
       publicKey: envParsed[publicKeyName],
-      privateKey: keysParsed[privateKeyName],
+      privateKey: existingPrivateKey,
       privateKeyAdded: false
     }
   }
 
   // generate key pair
-  const { publicKey, privateKey } = keyPair()
+  const { publicKey, privateKey } = keyPair(existingPrivateKey)
 
   // publicKey
   const prependPublicKey = [
@@ -67,15 +68,17 @@ function findOrCreatePublicKey (envFilepath, envKeysFilepath) {
   keysSrc = keysSrc.length > 1 ? keysSrc : `${firstTimeKeysSrc}\n`
   keysSrc = `${keysSrc}\n${appendPrivateKey}`
 
-  fs.writeFileSync(envFilepath, envSrc)
-  fs.writeFileSync(envKeysFilepath, keysSrc)
+  let privateKeyAdded = false
+  if (!existingPrivateKey) {
+    privateKeyAdded = true
+  }
 
   return {
     envSrc,
     keysSrc,
     publicKey,
     privateKey,
-    privateKeyAdded: true
+    privateKeyAdded
   }
 }
 

--- a/src/lib/helpers/findOrCreatePublicKey.js
+++ b/src/lib/helpers/findOrCreatePublicKey.js
@@ -24,15 +24,17 @@ function findOrCreatePublicKey (envFilepath, envKeysFilepath) {
   // parsed
   const envParsed = dotenv.parse(envSrc)
   const keysParsed = dotenv.parse(keysSrc)
+  const existingPublicKey = envParsed[publicKeyName]
   const existingPrivateKey = keysParsed[privateKeyName]
 
   // if DOTENV_PUBLIC_KEY_${environment} already present then go no further
-  if (envParsed[publicKeyName] && envParsed[publicKeyName].length > 0) {
+  if (existingPublicKey && existingPublicKey.length > 0) {
     return {
       envSrc,
       keysSrc,
-      publicKey: envParsed[publicKeyName],
+      publicKey: existingPublicKey,
       privateKey: existingPrivateKey,
+      publicKeyAdded: false,
       privateKeyAdded: false
     }
   }
@@ -66,10 +68,10 @@ function findOrCreatePublicKey (envFilepath, envKeysFilepath) {
 
   envSrc = `${prependPublicKey}\n${envSrc}`
   keysSrc = keysSrc.length > 1 ? keysSrc : `${firstTimeKeysSrc}\n`
-  keysSrc = `${keysSrc}\n${appendPrivateKey}`
 
   let privateKeyAdded = false
   if (!existingPrivateKey) {
+    keysSrc = `${keysSrc}\n${appendPrivateKey}`
     privateKeyAdded = true
   }
 
@@ -78,6 +80,7 @@ function findOrCreatePublicKey (envFilepath, envKeysFilepath) {
     keysSrc,
     publicKey,
     privateKey,
+    publicKeyAdded: true,
     privateKeyAdded
   }
 }

--- a/src/lib/helpers/keyPair.js
+++ b/src/lib/helpers/keyPair.js
@@ -1,7 +1,13 @@
 const { PrivateKey } = require('eciesjs')
 
-function keyPair () {
-  const kp = new PrivateKey()
+function keyPair (existingPrivateKey) {
+  let kp
+
+  if (existingPrivateKey) {
+    kp = new PrivateKey(Buffer.from(existingPrivateKey, 'hex'))
+  } else {
+    kp = new PrivateKey()
+  }
 
   const publicKey = kp.publicKey.toHex()
   const privateKey = kp.secret.toString('hex')

--- a/src/lib/services/encrypt.js
+++ b/src/lib/services/encrypt.js
@@ -45,18 +45,16 @@ class Encrypt {
           privateKeyAdded
         } = findOrCreatePublicKey(filepath, envKeysFilepath)
 
-        // handle writes
+        // handle .env.keys write
         fs.writeFileSync(envKeysFilepath, keysSrc)
 
+        src = envSrc // src was potentially modified by findOrCreatePublicKey so we set it again here
+
+        row.changed = publicKeyAdded // track change
         row.publicKey = publicKey
         row.privateKey = privateKey
-        row.privateKeyName = guessPrivateKeyName(filepath)
         row.privateKeyAdded = privateKeyAdded
-
-        src = envSrc // src was potentially changed by findOrCreatePublicKey so we set it again here
-
-        // track possible changes
-        row.changed = publicKeyAdded
+        row.privateKeyName = guessPrivateKeyName(filepath)
 
         // iterate over all non-encrypted values and encrypt them
         const parsed = dotenv.parse(src)

--- a/src/lib/services/encrypt.js
+++ b/src/lib/services/encrypt.js
@@ -41,11 +41,11 @@ class Encrypt {
           keysSrc,
           publicKey,
           privateKey,
+          publicKeyAdded,
           privateKeyAdded
         } = findOrCreatePublicKey(filepath, envKeysFilepath)
 
         // handle writes
-        fs.writeFileSync(filepath, envSrc)
         fs.writeFileSync(envKeysFilepath, keysSrc)
 
         row.publicKey = publicKey
@@ -56,7 +56,7 @@ class Encrypt {
         src = envSrc // src was potentially changed by findOrCreatePublicKey so we set it again here
 
         // track possible changes
-        row.changed = false
+        row.changed = publicKeyAdded
 
         // iterate over all non-encrypted values and encrypt them
         const parsed = dotenv.parse(src)

--- a/src/lib/services/encrypt.js
+++ b/src/lib/services/encrypt.js
@@ -38,10 +38,16 @@ class Encrypt {
         const envKeysFilepath = path.join(path.dirname(filepath), '.env.keys')
         const {
           envSrc,
+          keysSrc,
           publicKey,
           privateKey,
           privateKeyAdded
         } = findOrCreatePublicKey(filepath, envKeysFilepath)
+
+        // handle writes
+        fs.writeFileSync(filepath, envSrc)
+        fs.writeFileSync(envKeysFilepath, keysSrc)
+
         row.publicKey = publicKey
         row.privateKey = privateKey
         row.privateKeyName = guessPrivateKeyName(filepath)

--- a/src/lib/services/sets.js
+++ b/src/lib/services/sets.js
@@ -43,10 +43,15 @@ class Sets {
           const envKeysFilepath = path.join(path.dirname(filepath), '.env.keys')
           const {
             envSrc,
+            keysSrc,
             publicKey,
             privateKey,
             privateKeyAdded
           } = findOrCreatePublicKey(filepath, envKeysFilepath)
+          // handle writes
+          fs.writeFileSync(filepath, envSrc)
+          fs.writeFileSync(envKeysFilepath, keysSrc)
+
           src = envSrc // overwrite the original read (because findOrCreatePublicKey) rewrite to it
           value = encryptValue(value, publicKey)
 

--- a/src/lib/services/sets.js
+++ b/src/lib/services/sets.js
@@ -46,16 +46,18 @@ class Sets {
             keysSrc,
             publicKey,
             privateKey,
+            publicKeyAdded,
             privateKeyAdded
           } = findOrCreatePublicKey(filepath, envKeysFilepath)
-          // handle writes
-          fs.writeFileSync(filepath, envSrc)
+
+          // handle .env.keys write
           fs.writeFileSync(envKeysFilepath, keysSrc)
 
-          src = envSrc // overwrite the original read (because findOrCreatePublicKey) rewrite to it
+          src = envSrc // src was potentially modified by findOrCreatePublicKey so we set it again here
+
           value = encryptValue(value, publicKey)
 
-          row.changed = true // track change
+          row.changed = publicKeyAdded // track change
           row.encryptedValue = value
           row.publicKey = publicKey
           row.privateKey = privateKey

--- a/tests/lib/helpers/findOrCreatePublicKey.test.js
+++ b/tests/lib/helpers/findOrCreatePublicKey.test.js
@@ -1,6 +1,7 @@
 const t = require('tap')
 const fs = require('fs')
 const sinon = require('sinon')
+const dotenv = require('dotenv')
 
 const findOrCreatePublicKey = require('../../../src/lib/helpers/findOrCreatePublicKey')
 
@@ -10,20 +11,32 @@ let envKeysFile = 'tests/monorepo/apps/encrypted/.env.keys'
 t.beforeEach((ct) => {
   // important, clear process.env before each test
   process.env = {}
+
+  envFile = 'tests/monorepo/apps/encrypted/.env'
+  envKeysFile = 'tests/monorepo/apps/encrypted/.env.keys'
 })
 
-t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is found', ct => {
+t.test('#findOrCreatePublicKey when .env.keys AND DOTENV_PUBLIC_KEY is found', ct => {
+  const existingPublicKey = dotenv.parse(fs.readFileSync(envFile)).DOTENV_PUBLIC_KEY
+  const existingPrivateKey = dotenv.parse(fs.readFileSync(envKeysFile)).DOTENV_PRIVATE_KEY
+
   const {
     publicKey,
     privateKey,
+    publicKeyAdded,
     privateKeyAdded,
     envSrc,
     keysSrc
   } = findOrCreatePublicKey(envFile, envKeysFile)
 
   ct.same(publicKey, '03eaf2142ab3d55bdf108962334e06696db798e7412cfc51d75e74b4f87f299bba')
+  ct.same(publicKey, existingPublicKey)
+  ct.same(publicKeyAdded, false)
   ct.same(privateKey, 'ec9e80073d7ace817d35acb8b7293cbf8e5981b4d2f5708ee5be405122993cd1')
+  ct.same(privateKey, existingPrivateKey)
+  ct.same(privateKeyAdded, false)
 
+  // double check outputs
   const envOutput = [
     '#/-------------------[DOTENV_PUBLIC_KEY]--------------------/',
     '#/            public-key encryption for .env files          /',
@@ -45,16 +58,18 @@ t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is found', ct => {
     `DOTENV_PRIVATE_KEY="${privateKey}"`
   ].join('\n')
 
-  ct.same(privateKeyAdded, false)
   ct.same(envOutput.trim(), envSrc.trim())
   ct.same(envKeysOutput.trim(), keysSrc.trim())
 
   ct.end()
 })
 
-t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is NOT found', ct => {
+t.test('#findOrCreatePublicKey when no .env.keys file and no DOTENV_PUBLIC_KEY', ct => {
   envFile = 'tests/monorepo/apps/unencrypted/.env'
   envKeysFile = 'tests/monorepo/apps/unencrypted/.env.keys'
+
+  const existingPublicKey = dotenv.parse(fs.readFileSync(envFile)).DOTENV_PUBLIC_KEY
+  ct.same(existingPublicKey, undefined)
 
   const {
     publicKey,
@@ -64,6 +79,11 @@ t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is NOT found', ct => {
     keysSrc
   } = findOrCreatePublicKey(envFile, envKeysFile)
 
+  ct.ok(publicKey)
+  ct.ok(privateKey)
+  ct.same(privateKeyAdded, true)
+
+  // double check outputs
   const envOutput = [
     '#/-------------------[DOTENV_PUBLIC_KEY]--------------------/',
     '#/            public-key encryption for .env files          /',
@@ -85,14 +105,13 @@ t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is NOT found', ct => {
     `DOTENV_PRIVATE_KEY="${privateKey}"`
   ].join('\n')
 
-  ct.same(privateKeyAdded, true)
   ct.same(envOutput.trim(), envSrc.trim())
   ct.same(envKeysOutput.trim(), keysSrc.trim())
 
   ct.end()
 })
 
-t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is NOT found but .env.keys file is already found', ct => {
+t.test('#findOrCreatePublicKey when .env.keys found but with no DOTENV_PRIVATE_KEY and no DOTENV_PUBLIC_KEY', ct => {
   envFile = 'tests/monorepo/apps/unencrypted/.env'
   envKeysFile = 'tests/monorepo/apps/unencrypted/.env.keys'
 
@@ -115,6 +134,11 @@ t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is NOT found but .env.keys
     keysSrc
   } = findOrCreatePublicKey(envFile, envKeysFile)
 
+  ct.ok(publicKey)
+  ct.ok(privateKey)
+  ct.same(privateKeyAdded, true)
+
+  // double check outputs
   const envOutput = [
     '#/-------------------[DOTENV_PUBLIC_KEY]--------------------/',
     '#/            public-key encryption for .env files          /',
@@ -133,10 +157,77 @@ t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is NOT found but .env.keys
     `DOTENV_PRIVATE_KEY="${privateKey}"`
   ].join('\n')
 
-  ct.same(privateKeyAdded, true)
   ct.same(envOutput.trim(), envSrc.trim())
   ct.same(envKeysOutput.trim(), keysSrc.trim())
 
   existsSyncStub.restore()
+  sandbox.restore()
+
+  ct.end()
+})
+
+t.test('#findOrCreatePublicKey when .env.keys found but no DOTENV_PUBLIC_KEY', ct => {
+  const existsSyncStub = sinon.stub(fs, 'existsSync').returns(true)
+  const originalReadFileSync = fs.readFileSync
+  const sandbox = sinon.createSandbox()
+  sandbox.stub(fs, 'readFileSync').callsFake((filepath, options) => {
+    if (filepath === envFile) {
+      return 'HELLO="unencrypted"\n'
+    } else {
+      return originalReadFileSync(filepath, options)
+    }
+  })
+
+  const existingPublicKey = dotenv.parse(fs.readFileSync(envFile)).DOTENV_PUBLIC_KEY
+  const existingPrivateKey = dotenv.parse(fs.readFileSync(envKeysFile)).DOTENV_PRIVATE_KEY
+  console.log('envKeysFile', envKeysFile)
+
+  ct.same(existingPublicKey, undefined)
+  console.log('existingPrivateKey', existingPrivateKey)
+  ct.ok(existingPrivateKey)
+
+  const {
+    publicKey,
+    privateKey,
+    publicKeyAdded,
+    privateKeyAdded,
+    envSrc,
+    keysSrc
+  } = findOrCreatePublicKey(envFile, envKeysFile)
+
+  ct.notSame(publicKey, existingPublicKey)
+  ct.same(publicKeyAdded, true)
+  ct.same(privateKey, 'ec9e80073d7ace817d35acb8b7293cbf8e5981b4d2f5708ee5be405122993cd1')
+  ct.same(privateKey, existingPrivateKey)
+  ct.same(privateKeyAdded, false)
+
+  // double check outputs
+  const envOutput = [
+    '#/-------------------[DOTENV_PUBLIC_KEY]--------------------/',
+    '#/            public-key encryption for .env files          /',
+    '#/       [how it works](https://dotenvx.com/encryption)     /',
+    '#/----------------------------------------------------------/',
+    'DOTENV_PUBLIC_KEY="03eaf2142ab3d55bdf108962334e06696db798e7412cfc51d75e74b4f87f299bba"',
+    '',
+    '# .env',
+    'HELLO="unencrypted"'
+  ].join('\n')
+
+  const envKeysOutput = [
+    '#/------------------!DOTENV_PRIVATE_KEYS!-------------------/',
+    '#/ private decryption keys. DO NOT commit to source control /',
+    '#/     [how it works](https://dotenvx.com/encryption)       /',
+    '#/----------------------------------------------------------/',
+    '',
+    '# .env',
+    `DOTENV_PRIVATE_KEY="${privateKey}"`
+  ].join('\n')
+
+  ct.same(envOutput.trim(), envSrc.trim())
+  ct.same(envKeysOutput.trim(), keysSrc.trim())
+
+  existsSyncStub.restore()
+  sandbox.restore()
+
   ct.end()
 })

--- a/tests/lib/helpers/findOrCreatePublicKey.test.js
+++ b/tests/lib/helpers/findOrCreatePublicKey.test.js
@@ -24,6 +24,17 @@ t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is found', ct => {
   ct.same(publicKey, '03eaf2142ab3d55bdf108962334e06696db798e7412cfc51d75e74b4f87f299bba')
   ct.same(privateKey, 'ec9e80073d7ace817d35acb8b7293cbf8e5981b4d2f5708ee5be405122993cd1')
 
+  const envOutput = [
+    '#/-------------------[DOTENV_PUBLIC_KEY]--------------------/',
+    '#/            public-key encryption for .env files          /',
+    '#/       [how it works](https://dotenvx.com/encryption)     /',
+    '#/----------------------------------------------------------/',
+    'DOTENV_PUBLIC_KEY="03eaf2142ab3d55bdf108962334e06696db798e7412cfc51d75e74b4f87f299bba"',
+    '',
+    '# .env',
+    'HELLO="encrypted:BG8M6U+GKJGwpGA42ml2erb9+T2NBX6Z2JkBLynDy21poz0UfF5aPxCgRbIyhnQFdWKd0C9GZ7lM5PeL86xghoMcWvvPpkyQ0yaD2pZ64RzoxFGB1lTZYlEgQOxTDJnWxODHfuQcFY10uA=="'
+  ].join('\n')
+
   const envKeysOutput = [
     '#/------------------!DOTENV_PRIVATE_KEYS!-------------------/',
     '#/ private decryption keys. DO NOT commit to source control /',
@@ -35,6 +46,7 @@ t.test('#findOrCreatePublicKey when DOTENV_PUBLIC_KEY is found', ct => {
   ].join('\n')
 
   ct.same(privateKeyAdded, false)
+  ct.same(envOutput.trim(), envSrc.trim())
   ct.same(envKeysOutput.trim(), keysSrc.trim())
 
   ct.end()

--- a/tests/lib/helpers/keyPair.test.js
+++ b/tests/lib/helpers/keyPair.test.js
@@ -1,0 +1,31 @@
+const t = require('tap')
+const keyPair = require('../../../src/lib/helpers/keyPair')
+
+t.test('#keyPair', ct => {
+  const { publicKey, privateKey } = keyPair()
+
+  t.ok(publicKey, 'Public key should be defined')
+  t.ok(privateKey, 'Private key should be defined')
+  t.equal(publicKey.length, 66, 'Public key should be 66 characters long')
+  t.equal(privateKey.length, 64, 'Private key should be 64 characters long')
+
+  ct.end()
+})
+
+t.test('keyPair uses provided private key to generate public key', (t) => {
+  const existingPrivateKey = '4c06b1f9ffc4af11d0d206fd43f28bc96b68647158c1666edc4832f19857cef9'
+  const { publicKey, privateKey } = keyPair(existingPrivateKey)
+
+  t.equal(privateKey, existingPrivateKey, 'Private key should match the provided private key')
+  t.ok(publicKey, 'Public key should be defined')
+  t.equal(publicKey.length, 66, 'Public key should be 66 characters long')
+
+  // Generate the public key from the provided private key for comparison
+  const { PrivateKey } = require('eciesjs')
+  const kp = new PrivateKey(Buffer.from(existingPrivateKey, 'hex'))
+  const expectedPublicKey = kp.publicKey.toHex()
+
+  t.equal(publicKey, expectedPublicKey, 'Public key should match the expected public key generated from the provided private key')
+
+  t.end()
+})


### PR DESCRIPTION
wip. needs to better consider usage when first running encrypt on `.env`.

it will currently modify still - because it needs to generate the DOTENV_PUBLIC_KEY. that seems unexpected when using, though it does make sense for it to be there. otherwise, we're left asking the user to pass a public key, which seems burdensome. 

have to think on this one some more.