### PR TITLE
Decrypt expanded values if necessary

### DIFF
--- a/src/lib/helpers/parseDecryptEvalExpand.js
+++ b/src/lib/helpers/parseDecryptEvalExpand.js
@@ -32,7 +32,9 @@ function parseDecryptEvalExpand (src, privateKey = null, processEnv = process.en
   // for logging only log the original keys existing in parsed. this feels unnecessarily complex - like dotenv-expand should support the ability to inject additional `process.env` or objects as it sees fit to the object it wants to expand
   const result = {}
   for (const key in parsed) {
-    result[key] = expanded.parsed[key]
+    const value = expanded.parsed[key]
+    // decrypt again if necessary, since dotenv-expand may have expanded an encrypted value
+    result[key] = privateKey && privateKey.length ? decryptValue(value, privateKey) : value
   }
 
   return { parsed: result, processEnv }


### PR DESCRIPTION
This enables delegated expansion using dynamically loaded environment files in cloud deployments, instead of shipping custom container images for each env file, or needing to deal with volume mount annoyances. You can dynamically provide an environment decryption key using `DOTENV_PRIVATE_KEY` as a cloud secret.

The solution I came up with:

`.env` (shipped in container image):
```
FOO=${FOO_ENC}
BAR=${BAR_ENC}
```

`.env.{environment}` (loaded into cloud environment using `docker --env-file`):
```
FOO_ENC=encrypted:woefijweoif
BAR_ENC=encrypted:jsdfkjfowe 
```

A bug remains where the `FOO_ENC` variables cannot be quoted - I suspect this should be fixed somewhere in the eval/expand logic but I didn't have time to dig.

An _additional_ bug remains where you cannot just do `FOO=${FOO}` in the `.env`, which was going to be my original solution to force decryption through `dotenvx` file for variables passed in the environment. But that also doesn't work due to what I assume is a short-circuit in `eval` or `expand`.

My current temporary solution is even uglier: the container `entrypoint.sh` writes an allow-list of encrypted environment variables to `.env` which is then loaded with a stock `dotenvx` and decrypted with `DOTENV_PRIVATE_KEY` from a cloud secret.