### PR TITLE
replace `chalk` with `picocolors` and `color-name`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "chalk": "^4.1.2",
+        "color-name": "^1.1.4",
         "commander": "^11.1.0",
         "diff": "^5.2.0",
         "dotenv": "^16.4.5",
@@ -17,6 +17,7 @@
         "fdir": "^6.2.0",
         "ignore": "^5.3.0",
         "object-treeify": "1.1.33",
+        "picocolors": "^1.0.1",
         "picomatch": "^4.0.2",
         "tinyexec": "^0.2.0",
         "which": "^4.0.0",
@@ -1915,6 +1916,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2457,6 +2459,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2704,6 +2707,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4828,6 +4832,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7504,6 +7509,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+    },
     "node_modules/picomatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -9381,6 +9391,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "funding": "https://dotenvx.com",
   "dependencies": {
-    "chalk": "^4.1.2",
+    "color-name": "^1.1.4",
     "commander": "^11.1.0",
     "diff": "^5.2.0",
     "dotenv": "^16.4.5",
@@ -44,6 +44,7 @@
     "fdir": "^6.2.0",
     "ignore": "^5.3.0",
     "object-treeify": "1.1.33",
+    "picocolors": "^1.0.1",
     "picomatch": "^4.0.2",
     "tinyexec": "^0.2.0",
     "which": "^4.0.0",

--- a/src/lib/services/status.js
+++ b/src/lib/services/status.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const diff = require('diff')
-const chalk = require('chalk')
+const pc = require('picocolors')
 
 const Ls = require('./ls')
 const VaultDecrypt = require('./vaultDecrypt')
@@ -94,12 +94,12 @@ class Status {
   _colorizeDiff (part) {
     // If the part was added, color it green
     if (part.added) {
-      return chalk.green(part.value)
+      return pc.green(part.value)
     }
 
     // If the part was removed, color it red
     if (part.removed) {
-      return chalk.red(part.value)
+      return pc.red(part.value)
     }
 
     // No color for unchanged parts

--- a/src/shared/logger.js
+++ b/src/shared/logger.js
@@ -1,5 +1,6 @@
 const winston = require('winston')
-const chalk = require('chalk')
+const colors = require('color-name')
+const pc = require('picocolors')
 
 const printf = winston.format.printf
 const combine = winston.format.combine
@@ -32,15 +33,24 @@ const levels = {
   silly: 6
 }
 
-const error = chalk.bold.red
-const warn = chalk.keyword('orangered')
-const success = chalk.keyword('green')
-const successv = chalk.keyword('olive') // yellow-ish tint that 'looks' like dotenv
-const help = chalk.keyword('blue')
-const help2 = chalk.keyword('gray')
-const http = chalk.keyword('green')
-const verbose = chalk.keyword('plum')
-const debug = chalk.keyword('plum')
+function getColor (color) {
+  if (!Object.hasOwn(colors, color)) {
+    throw new Error(`Invalid color ${color}`)
+  }
+  if (!pc.isColorSupported) return (message) => message
+  const [r, g, b] = colors[color]
+  return (message) => `\x1b[38;2;${r};${g};${b}m${message}\x1b[39m`
+}
+
+const error = (m) => pc.bold(pc.red(m))
+const warn = getColor('orangered')
+const success = getColor('green')
+const successv = getColor('olive') // yellow-ish tint that 'looks' like dotenv
+const help = getColor('blue')
+const help2 = getColor('gray')
+const http = getColor('green')
+const verbose = getColor('plum')
+const debug = getColor('plum')
 
 const dotenvxFormat = printf(({ level, message, label, timestamp }) => {
   const formattedMessage = typeof message === 'object' ? JSON.stringify(message) : message
@@ -119,5 +129,6 @@ const setLogLevel = options => {
 
 module.exports = {
   logger,
+  getColor,
   setLogLevel
 }

--- a/tests/shared/logger.test.js
+++ b/tests/shared/logger.test.js
@@ -1,9 +1,10 @@
 const capcon = require('capture-console')
 const t = require('tap')
-const chalk = require('chalk')
+const pc = require('picocolors')
+const sinon = require('sinon')
 
 const packageJson = require('../../src/lib/helpers/packageJson')
-const { logger } = require('../../src/shared/logger')
+const { getColor, logger } = require('../../src/shared/logger')
 
 t.test('logger.blank', (ct) => {
   const message = 'message1'
@@ -60,7 +61,7 @@ t.test('logger.help2', (ct) => {
     logger.help2(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('gray')('message1')}\n`)
+  ct.equal(stdout, `${getColor('gray')('message1')}\n`)
 
   ct.end()
 })
@@ -72,7 +73,7 @@ t.test('logger.help', (ct) => {
     logger.help(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('blue')('message1')}\n`)
+  ct.equal(stdout, `${getColor('blue')('message1')}\n`)
 
   ct.end()
 })
@@ -96,7 +97,7 @@ t.test('logger.successvpb', (ct) => {
     logger.successvpb(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('green')(`[dotenvx@${packageJson.version}][prebuild] message1`)}\n`)
+  ct.equal(stdout, `${getColor('green')(`[dotenvx@${packageJson.version}][prebuild] message1`)}\n`)
 
   ct.end()
 })
@@ -108,7 +109,7 @@ t.test('logger.successvp', (ct) => {
     logger.successvp(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('green')(`[dotenvx@${packageJson.version}][precommit] message1`)}\n`)
+  ct.equal(stdout, `${getColor('green')(`[dotenvx@${packageJson.version}][precommit] message1`)}\n`)
 
   ct.end()
 })
@@ -120,7 +121,7 @@ t.test('logger.successv', (ct) => {
     logger.successv(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('olive')(`[dotenvx@${packageJson.version}] message1`)}\n`)
+  ct.equal(stdout, `${getColor('olive')(`[dotenvx@${packageJson.version}] message1`)}\n`)
 
   ct.end()
 })
@@ -132,7 +133,7 @@ t.test('logger.success', (ct) => {
     logger.success(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('green')('message1')}\n`)
+  ct.equal(stdout, `${getColor('green')('message1')}\n`)
 
   ct.end()
 })
@@ -144,7 +145,7 @@ t.test('logger.warnvpb', (ct) => {
     logger.warnvpb(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('orangered')(`[dotenvx@${packageJson.version}][prebuild] message1`)}\n`)
+  ct.equal(stdout, `${getColor('orangered')(`[dotenvx@${packageJson.version}][prebuild] message1`)}\n`)
 
   ct.end()
 })
@@ -156,7 +157,7 @@ t.test('logger.warnvp', (ct) => {
     logger.warnvp(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('orangered')(`[dotenvx@${packageJson.version}][precommit] message1`)}\n`)
+  ct.equal(stdout, `${getColor('orangered')(`[dotenvx@${packageJson.version}][precommit] message1`)}\n`)
 
   ct.end()
 })
@@ -168,7 +169,7 @@ t.test('logger.warnv', (ct) => {
     logger.warnv(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('orangered')(`[dotenvx@${packageJson.version}] message1`)}\n`)
+  ct.equal(stdout, `${getColor('orangered')(`[dotenvx@${packageJson.version}] message1`)}\n`)
 
   ct.end()
 })
@@ -180,7 +181,7 @@ t.test('logger.warn', (ct) => {
     logger.warn(message)
   })
 
-  ct.equal(stdout, `${chalk.keyword('orangered')('message1')}\n`)
+  ct.equal(stdout, `${getColor('orangered')('message1')}\n`)
 
   ct.end()
 })
@@ -192,7 +193,7 @@ t.test('logger.errorvpb', (ct) => {
     logger.errorvpb(message)
   })
 
-  ct.equal(stdout, `${chalk.bold.red(`[dotenvx@${packageJson.version}][prebuild] message1`)}\n`)
+  ct.equal(stdout, `${pc.bold(pc.red(`[dotenvx@${packageJson.version}][prebuild] message1`))}\n`)
 
   ct.end()
 })
@@ -204,7 +205,7 @@ t.test('logger.errorvp', (ct) => {
     logger.errorvp(message)
   })
 
-  ct.equal(stdout, `${chalk.bold.red(`[dotenvx@${packageJson.version}][precommit] message1`)}\n`)
+  ct.equal(stdout, `${pc.bold(pc.red(`[dotenvx@${packageJson.version}][precommit] message1`))}\n`)
 
   ct.end()
 })
@@ -216,7 +217,7 @@ t.test('logger.errorv', (ct) => {
     logger.errorv(message)
   })
 
-  ct.equal(stdout, `${chalk.bold.red(`[dotenvx@${packageJson.version}] message1`)}\n`)
+  ct.equal(stdout, `${pc.bold(pc.red(`[dotenvx@${packageJson.version}] message1`))}\n`)
 
   ct.end()
 })
@@ -228,7 +229,7 @@ t.test('logger.error', (ct) => {
     logger.error(message)
   })
 
-  ct.equal(stdout, `${chalk.bold.red('message1')}\n`)
+  ct.equal(stdout, `${pc.bold(pc.red('message1'))}\n`)
 
   ct.end()
 })
@@ -253,6 +254,37 @@ t.test('logger.blank as object', (ct) => {
   })
 
   ct.equal(stdout, `${JSON.stringify({ key: 'value' })}\n`)
+
+  ct.end()
+})
+
+t.test('getColor with color support', (ct) => {
+  const stub = sinon.stub(pc, 'isColorSupported').value(true)
+
+  ct.equal(getColor('red')('hello'), '\x1b[38;2;255;0;0mhello\x1b[39m')
+
+  stub.restore()
+  ct.end()
+})
+
+t.test('getColor without color support', (ct) => {
+  const stub = sinon.stub(pc, 'isColorSupported').value(false)
+
+  ct.equal(getColor('red')('hello'), 'hello')
+
+  stub.restore()
+  ct.end()
+})
+
+t.test('getColor invalid color', (ct) => {
+  try {
+    getColor('invalid color')
+
+    ct.fail('getColor should throw error')
+  } catch (error) {
+    ct.pass(' threw an error')
+    ct.equal(error.message, 'Invalid color invalid color')
+  }
 
   ct.end()
 })


### PR DESCRIPTION
part of trying to refactor the logger to eventually remove winston, realized `chalk` can be replaced without outright removing `winston`

was originally gonna use `color-convert` but the use here can be cleanly replaced with just `color-name`, which both `chalk` and `color-convert` use

- [`chalk@4`](https://npmgraph.js.org/?q=chalk@4) - 5 subdependencies
- [`picocolors`](https://npmgraph.js.org/?q=picocolors) - 0 subdependencies
- [`color-name`](https://npmgraph.js.org/?q=color-name) - 0 subdependencies