### PR TITLE
use ansi256 colors instead of rgb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "color-name": "^1.1.4",
         "commander": "^11.1.0",
         "diff": "^5.2.0",
         "dotenv": "^16.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "fdir": "^6.2.0",
         "ignore": "^5.3.0",
         "object-treeify": "1.1.33",
-        "picocolors": "^1.0.1",
         "picomatch": "^4.0.2",
         "tinyexec": "^0.2.0",
         "which": "^4.0.0",
@@ -7507,11 +7506,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "fdir": "^6.2.0",
     "ignore": "^5.3.0",
     "object-treeify": "1.1.33",
-    "picocolors": "^1.0.1",
     "picomatch": "^4.0.2",
     "tinyexec": "^0.2.0",
     "which": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "funding": "https://dotenvx.com",
   "dependencies": {
-    "color-name": "^1.1.4",
     "commander": "^11.1.0",
     "diff": "^5.2.0",
     "dotenv": "^16.4.5",

--- a/src/lib/helpers/colorDepth.js
+++ b/src/lib/helpers/colorDepth.js
@@ -1,0 +1,4 @@
+const { WriteStream } = require('tty')
+const getColorDepth = () => WriteStream.prototype.getColorDepth() ?? 2
+
+module.exports = { getColorDepth }

--- a/src/lib/services/status.js
+++ b/src/lib/services/status.js
@@ -1,13 +1,13 @@
 const fs = require('fs')
 const path = require('path')
 const diff = require('diff')
-const pc = require('picocolors')
 
 const Ls = require('./ls')
 const VaultDecrypt = require('./vaultDecrypt')
 
 const containsDirectory = require('./../helpers/containsDirectory')
 const guessEnvironment = require('./../helpers/guessEnvironment')
+const { getColor } = require('./../../shared/colors')
 
 const ENCODING = 'utf8'
 
@@ -94,12 +94,12 @@ class Status {
   _colorizeDiff (part) {
     // If the part was added, color it green
     if (part.added) {
-      return pc.green(part.value)
+      return getColor('green')(part.value)
     }
 
     // If the part was removed, color it red
     if (part.removed) {
-      return pc.red(part.value)
+      return getColor('red')(part.value)
     }
 
     // No color for unchanged parts

--- a/src/shared/colors.js
+++ b/src/shared/colors.js
@@ -1,0 +1,50 @@
+const depth = require('../lib/helpers/colorDepth')
+
+const colors16 = new Map([
+  ['blue', 34],
+  ['gray', 37],
+  ['green', 32],
+  ['olive', 33],
+  ['orangered', 91],
+  ['plum', 97],
+  ['red', 31]
+])
+
+const colors256 = new Map([
+  ['blue', 21],
+  ['gray', 244],
+  ['green', 34],
+  ['olive', 142],
+  ['orangered', 202],
+  ['plum', 182],
+  ['red', 196]
+])
+
+function getColor (color) {
+  const colorDepth = depth.getColorDepth()
+  if (!colors256.has(color)) {
+    throw new Error(`Invalid color ${color}`)
+  }
+  if (colorDepth >= 256) {
+    const code = colors256.get(color)
+    return (message) => `\x1b[38;5;${code}m${message}\x1b[39m`
+  }
+  if (colorDepth >= 16) {
+    const code = colors16.get(color)
+    return (message) => `\x1b[${code}m${message}\x1b[39m`
+  }
+  return (message) => message
+}
+
+function bold (message) {
+  if (depth.getColorDepth() >= 16) {
+    return `\x1b[1m${message}\x1b[22m`
+  }
+
+  return message
+}
+
+module.exports = {
+  getColor,
+  bold
+}

--- a/src/shared/logger.js
+++ b/src/shared/logger.js
@@ -1,21 +1,12 @@
 const winston = require('winston')
-const pc = require('picocolors')
 
 const printf = winston.format.printf
 const combine = winston.format.combine
 const createLogger = winston.createLogger
 const transports = winston.transports
 
-const packageJson = require('./../lib/helpers/packageJson')
-
-const colors = new Map([
-  ['blue', 21],
-  ['green', 34],
-  ['olive', 142],
-  ['plum', 182],
-  ['orangered', 202],
-  ['gray', 244]
-])
+const packageJson = require('../lib/helpers/packageJson')
+const { getColor, bold } = require('./colors')
 
 const levels = {
   error: 0,
@@ -41,16 +32,7 @@ const levels = {
   silly: 6
 }
 
-function getColor (color) {
-  if (!colors.has(color)) {
-    throw new Error(`Invalid color ${color}`)
-  }
-  if (!pc.isColorSupported) return (message) => message
-  const code = colors.get(color)
-  return (message) => `\x1b[38;5;${code}m${message}\x1b[39m`
-}
-
-const error = (m) => pc.bold(pc.red(m))
+const error = (m) => bold(getColor('red')(m))
 const warn = getColor('orangered')
 const success = getColor('green')
 const successv = getColor('olive') // yellow-ish tint that 'looks' like dotenv

--- a/src/shared/logger.js
+++ b/src/shared/logger.js
@@ -1,5 +1,4 @@
 const winston = require('winston')
-const colors = require('color-name')
 const pc = require('picocolors')
 
 const printf = winston.format.printf
@@ -8,6 +7,15 @@ const createLogger = winston.createLogger
 const transports = winston.transports
 
 const packageJson = require('./../lib/helpers/packageJson')
+
+const colors = new Map([
+  ['blue', 21],
+  ['green', 34],
+  ['olive', 142],
+  ['plum', 182],
+  ['orangered', 202],
+  ['gray', 244]
+])
 
 const levels = {
   error: 0,
@@ -34,12 +42,12 @@ const levels = {
 }
 
 function getColor (color) {
-  if (!Object.hasOwn(colors, color)) {
+  if (!colors.has(color)) {
     throw new Error(`Invalid color ${color}`)
   }
   if (!pc.isColorSupported) return (message) => message
-  const [r, g, b] = colors[color]
-  return (message) => `\x1b[38;2;${r};${g};${b}m${message}\x1b[39m`
+  const code = colors.get(color)
+  return (message) => `\x1b[38;5;${code}m${message}\x1b[39m`
 }
 
 const error = (m) => pc.bold(pc.red(m))

--- a/tests/lib/helpers/colorDepth.test.js
+++ b/tests/lib/helpers/colorDepth.test.js
@@ -1,0 +1,22 @@
+const { WriteStream } = require('tty')
+const t = require('tap')
+const sinon = require('sinon')
+
+const depth = require('../../../src/lib/helpers/colorDepth')
+
+t.test('returns WriteStream.prototype.getColorDepth() if present', (ct) => {
+  const stub = sinon.stub(WriteStream.prototype, 'getColorDepth').returns(256)
+  ct.equal(depth.getColorDepth(), 256)
+
+  stub.restore()
+  ct.end()
+})
+
+t.test('defaults to 2', (ct) => {
+  const stub = sinon.stub(WriteStream.prototype, 'getColorDepth').returns(null)
+
+  ct.equal(depth.getColorDepth(), 2)
+
+  stub.restore()
+  ct.end()
+})

--- a/tests/shared/colors.test.js
+++ b/tests/shared/colors.test.js
@@ -1,0 +1,63 @@
+const t = require('tap')
+const sinon = require('sinon')
+
+const { getColor, bold } = require('../../src/shared/colors')
+const depth = require('../../src/lib/helpers/colorDepth')
+
+t.test('getColor with ansi256 color support', (ct) => {
+  const stub = sinon.stub(depth, 'getColorDepth').returns(256)
+
+  ct.equal(getColor('orangered')('hello'), '\x1b[38;5;202mhello\x1b[39m')
+
+  stub.restore()
+  ct.end()
+})
+
+t.test('getColor with ansi16 color support', (ct) => {
+  const stub = sinon.stub(depth, 'getColorDepth').returns(16)
+
+  ct.equal(getColor('orangered')('hello'), '\x1b[91mhello\x1b[39m')
+
+  stub.restore()
+  ct.end()
+})
+
+t.test('getColor without color support', (ct) => {
+  const stub = sinon.stub(depth, 'getColorDepth').returns(2)
+
+  ct.equal(getColor('orangered')('hello'), 'hello')
+
+  stub.restore()
+  ct.end()
+})
+
+t.test('getColor invalid color', (ct) => {
+  try {
+    getColor('invalid')
+
+    ct.fail('getColor should throw error')
+  } catch (error) {
+    ct.pass(' threw an error')
+    ct.equal(error.message, 'Invalid color invalid')
+  }
+
+  ct.end()
+})
+
+t.test('bold with ansi16 color support', (ct) => {
+  const stub = sinon.stub(depth, 'getColorDepth').returns(16)
+
+  ct.equal(bold('hello'), '\x1b[1mhello\x1b[22m')
+
+  stub.restore()
+  ct.end()
+})
+
+t.test('bold without color support', (ct) => {
+  const stub = sinon.stub(depth, 'getColorDepth').returns(2)
+
+  ct.equal(bold('hello'), 'hello')
+
+  stub.restore()
+  ct.end()
+})

--- a/tests/shared/logger.test.js
+++ b/tests/shared/logger.test.js
@@ -1,10 +1,9 @@
 const capcon = require('capture-console')
 const t = require('tap')
-const pc = require('picocolors')
-const sinon = require('sinon')
 
 const packageJson = require('../../src/lib/helpers/packageJson')
-const { getColor, logger } = require('../../src/shared/logger')
+const { getColor, bold } = require('../../src/shared/colors')
+const { logger } = require('../../src/shared/logger')
 
 t.test('logger.blank', (ct) => {
   const message = 'message1'
@@ -193,7 +192,7 @@ t.test('logger.errorvpb', (ct) => {
     logger.errorvpb(message)
   })
 
-  ct.equal(stdout, `${pc.bold(pc.red(`[dotenvx@${packageJson.version}][prebuild] message1`))}\n`)
+  ct.equal(stdout, `${bold(getColor('red')(`[dotenvx@${packageJson.version}][prebuild] message1`))}\n`)
 
   ct.end()
 })
@@ -205,7 +204,7 @@ t.test('logger.errorvp', (ct) => {
     logger.errorvp(message)
   })
 
-  ct.equal(stdout, `${pc.bold(pc.red(`[dotenvx@${packageJson.version}][precommit] message1`))}\n`)
+  ct.equal(stdout, `${bold(getColor('red')(`[dotenvx@${packageJson.version}][precommit] message1`))}\n`)
 
   ct.end()
 })
@@ -217,7 +216,7 @@ t.test('logger.errorv', (ct) => {
     logger.errorv(message)
   })
 
-  ct.equal(stdout, `${pc.bold(pc.red(`[dotenvx@${packageJson.version}] message1`))}\n`)
+  ct.equal(stdout, `${bold(getColor('red')(`[dotenvx@${packageJson.version}] message1`))}\n`)
 
   ct.end()
 })
@@ -229,7 +228,7 @@ t.test('logger.error', (ct) => {
     logger.error(message)
   })
 
-  ct.equal(stdout, `${pc.bold(pc.red('message1'))}\n`)
+  ct.equal(stdout, `${bold(getColor('red')('message1'))}\n`)
 
   ct.end()
 })
@@ -254,37 +253,6 @@ t.test('logger.blank as object', (ct) => {
   })
 
   ct.equal(stdout, `${JSON.stringify({ key: 'value' })}\n`)
-
-  ct.end()
-})
-
-t.test('getColor with color support', (ct) => {
-  const stub = sinon.stub(pc, 'isColorSupported').value(true)
-
-  ct.equal(getColor('orangered')('hello'), '\x1b[38;5;202mhello\x1b[39m')
-
-  stub.restore()
-  ct.end()
-})
-
-t.test('getColor without color support', (ct) => {
-  const stub = sinon.stub(pc, 'isColorSupported').value(false)
-
-  ct.equal(getColor('orangered')('hello'), 'hello')
-
-  stub.restore()
-  ct.end()
-})
-
-t.test('getColor invalid color', (ct) => {
-  try {
-    getColor('invalid')
-
-    ct.fail('getColor should throw error')
-  } catch (error) {
-    ct.pass(' threw an error')
-    ct.equal(error.message, 'Invalid color invalid')
-  }
 
   ct.end()
 })

--- a/tests/shared/logger.test.js
+++ b/tests/shared/logger.test.js
@@ -261,7 +261,7 @@ t.test('logger.blank as object', (ct) => {
 t.test('getColor with color support', (ct) => {
   const stub = sinon.stub(pc, 'isColorSupported').value(true)
 
-  ct.equal(getColor('red')('hello'), '\x1b[38;2;255;0;0mhello\x1b[39m')
+  ct.equal(getColor('orangered')('hello'), '\x1b[38;5;202mhello\x1b[39m')
 
   stub.restore()
   ct.end()
@@ -270,7 +270,7 @@ t.test('getColor with color support', (ct) => {
 t.test('getColor without color support', (ct) => {
   const stub = sinon.stub(pc, 'isColorSupported').value(false)
 
-  ct.equal(getColor('red')('hello'), 'hello')
+  ct.equal(getColor('orangered')('hello'), 'hello')
 
   stub.restore()
   ct.end()
@@ -278,12 +278,12 @@ t.test('getColor without color support', (ct) => {
 
 t.test('getColor invalid color', (ct) => {
   try {
-    getColor('invalid color')
+    getColor('invalid')
 
     ct.fail('getColor should throw error')
   } catch (error) {
     ct.pass(' threw an error')
-    ct.equal(error.message, 'Invalid color invalid color')
+    ct.equal(error.message, 'Invalid color invalid')
   }
 
   ct.end()


### PR DESCRIPTION
removes `color-name`, ~~didn't remove `picocolors` due to it using standard 16 color ansi codes instead of 256~~

(above is `picocolors` red, below is ansi256 red, small difference. ~~i can remove `picocolors` if that's not a problem though~~)
![image](https://github.com/user-attachments/assets/9b94920b-0e95-4372-b9de-4f1c7f371c11)

removed `picocolors` as well 💪