### PR TITLE
Fix: dotenvx precommit hook should check subfolders

### DIFF
--- a/src/lib/services/precommit.js
+++ b/src/lib/services/precommit.js
@@ -2,17 +2,19 @@
 const fs = require('fs')
 const ignore = require('ignore')
 
+const Ls = require('../services/ls')
+
 const pluralize = require('./../helpers/pluralize')
 const isFullyEncrypted = require('./../helpers/isFullyEncrypted')
 const InstallPrecommitHook = require('./../helpers/installPrecommitHook')
 const MISSING_GITIGNORE = '.env.keys' // by default only ignore .env.keys. all other .env* files COULD be included - as long as they are encrypted
 
 class Precommit {
-  constructor (options = {}) {
+  constructor(options = {}) {
     this.install = options.install
   }
 
-  run () {
+  run() {
     if (this.install) {
       const {
         successMessage
@@ -38,8 +40,8 @@ class Precommit {
 
       // 2. check .env* files against .gitignore file
       const ig = ignore().add(gitignore)
-      const files = fs.readdirSync(process.cwd())
-      const dotenvFiles = files.filter(file => file.match(/^\.env(\..+)?$/))
+      const lsService = new Ls(process.cwd())
+      const dotenvFiles = lsService.run()
       dotenvFiles.forEach(file => {
         // check if that file is being ignored
         if (ig.ignores(file)) {
@@ -74,7 +76,7 @@ class Precommit {
     }
   }
 
-  _installPrecommitHook () {
+  _installPrecommitHook() {
     return new InstallPrecommitHook().run()
   }
 }

--- a/tests/lib/services/precommit.test.js
+++ b/tests/lib/services/precommit.test.js
@@ -4,8 +4,11 @@ const sinon = require('sinon')
 
 const Precommit = require('../../../src/lib/services/precommit')
 const InstallPrecommitHook = require('../../../src/lib/helpers/installPrecommitHook')
+const Ls = require('../../../src/lib/services/ls')
 
 t.test('#run', ct => {
+  const lsServiceStub = sinon.stub(Ls.prototype, "run")
+  lsServiceStub.returns([])
   const precommit = new Precommit()
   const installPrecommitHookStub = sinon.stub(precommit, '_installPrecommitHook')
 
@@ -14,7 +17,7 @@ t.test('#run', ct => {
   t.ok(installPrecommitHookStub.notCalled, '_installPrecommitHook should not be called')
 
   installPrecommitHookStub.restore()
-
+  lsServiceStub.restore()
   ct.end()
 })
 
@@ -28,18 +31,20 @@ t.test('#run (install: true)', ct => {
   t.ok(installPrecommitHookStub.called, '_installPrecommitHook should be called')
 
   installPrecommitHookStub.restore()
-
   ct.end()
 })
 
 t.test('#run (no gitignore file)', ct => {
   const existsSyncStub = sinon.stub(fs, 'existsSync')
   existsSyncStub.returns(false)
+  const lsServiceStub = sinon.stub(Ls.prototype, "run")
+  lsServiceStub.returns([])
 
   const { warnings } = new Precommit().run()
   ct.same(warnings[0].message, '.gitignore missing')
 
   existsSyncStub.restore()
+  lsServiceStub.restore()
   ct.end()
 })
 
@@ -48,6 +53,8 @@ t.test('#run (gitignore is ignoring .env.example file and shouldn\'t)', ct => {
   readFileSyncStub.returns('.env*')
   const readdirSyncStub = sinon.stub(fs, 'readdirSync')
   readdirSyncStub.returns(['.env.example'])
+  const lsServiceStub = sinon.stub(Ls.prototype, "run")
+  lsServiceStub.returns(['.env.example'])
 
   const { warnings } = new Precommit().run()
 
@@ -55,6 +62,7 @@ t.test('#run (gitignore is ignoring .env.example file and shouldn\'t)', ct => {
 
   readFileSyncStub.restore()
   readdirSyncStub.restore()
+  lsServiceStub.restore()
   ct.end()
 })
 
@@ -63,19 +71,22 @@ t.test('#run (gitignore is ignoring .env.vault file and shouldn\'t)', ct => {
   readFileSyncStub.returns('.env*')
   const readdirSyncStub = sinon.stub(fs, 'readdirSync')
   readdirSyncStub.returns(['.env.vault'])
+  const lsServiceStub = sinon.stub(Ls.prototype, 'run')
+  lsServiceStub.returns(['.env.vault'])
 
   const { warnings } = new Precommit().run()
-
   ct.same(warnings[0].message, '.env.vault (currently ignored but should not be)')
 
   readFileSyncStub.restore()
   readdirSyncStub.restore()
+  lsServiceStub.restore()
   ct.end()
 })
 
 t.test('#run (gitignore is not ignore .env.production file and should)', ct => {
+  const lsServiceStub = sinon.stub(Ls.prototype, 'run')
+  lsServiceStub.returns(['.env.production'])
   const readFileSyncStub = sinon.stub(fs, 'readFileSync')
-
   // Stub different return values based on the file path
   readFileSyncStub.callsFake((filePath) => {
     if (filePath === '.env') {
@@ -86,9 +97,6 @@ t.test('#run (gitignore is not ignore .env.production file and should)', ct => {
     return ''
   })
 
-  const readdirSyncStub = sinon.stub(fs, 'readdirSync')
-  readdirSyncStub.returns(['.env.production'])
-
   try {
     new Precommit().run()
     ct.fail('should have raised an error but did not')
@@ -97,7 +105,31 @@ t.test('#run (gitignore is not ignore .env.production file and should)', ct => {
   }
 
   readFileSyncStub.restore()
-  readdirSyncStub.restore()
+  lsServiceStub.restore()
+  ct.end()
+})
+
+t.test('#run (.env files in subfolders throw error in precommit hook)', ct => {
+  const lsServiceStub = sinon.stub(Ls.prototype, 'run')
+  lsServiceStub.returns(['packages/app/.env.production'])
+
+  const readFileSyncStub = sinon.stub(fs, 'readFileSync')
+  readFileSyncStub.callsFake((filePath) => {
+    if (filePath === 'packages/app/.env.production') {
+      return 'ENV_VAR=value'
+    }
+    return ''
+  })
+
+  try {
+    new Precommit().run()
+    ct.fail('should have raised an error but did not')
+  } catch (error) {
+    ct.same(error.message, 'packages/app/.env.production not encrypted (or not gitignored)')
+  }
+
+  lsServiceStub.restore()
+  readFileSyncStub.restore()
   ct.end()
 })
 


### PR DESCRIPTION
## What does this PR include?
This PR includes a fix to #333 which includes more context on the overall issue.

I used the [`Ls` class in `src/lib/services/ls.js`](https://github.com/dotenvx/dotenvx/blob/main/src/lib/services/ls.js) to find all the `.env*` files in the repository as part of the precommit hook. If any of these files are not encrypted the pre-commit hook will throw. 

The fix was actually pretty easy to implement, I just had to fight with the tests for awhile 😅
Let me know if there's anything else I should clean up before we can merge.    