### PR TITLE
add `--format` option to get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [Unreleased](https://github.com/dotenvx/dotenvx/compare/v1.11.5...main)
+## [Unreleased](https://github.com/dotenvx/dotenvx/compare/v1.12.0...main)
+
+## 1.12.0
+
+* add `dotenvx get --format shell` option ([#363](https://github.com/dotenvx/dotenvx/pull/363))
 
 ## 1.11.5
 

--- a/README.md
+++ b/README.md
@@ -1042,6 +1042,31 @@ More examples
   ```
 
   </details>
+* <details><summary>`get --format shell`</summary><br>
+
+  Return a shell formatted response of all key/value pairs in a `.env` file.
+
+  ```sh
+  $ echo "HELLO=World\n" > .env
+  $ echo "KEY=value\n" >> .env
+
+  $ dotenvx get --format shell
+  HELLO="World" KEY="value"
+  ```
+
+  This can be useful when combined with `env` on the command line.
+
+  ```
+  $ env $(dotenvx get format --shell) your-command
+  ```
+
+  or with `export`.
+
+  ```
+  $ export $(dotenvx get format --shell) your-command
+  ```
+
+  </details>
 * <details><summary>`get --all`</summary><br>
 
   Return preset machine envs as well.

--- a/src/cli/actions/get.js
+++ b/src/cli/actions/get.js
@@ -27,9 +27,9 @@ function get (key) {
     if (options.format === 'shell') {
       let inline = ''
       for (const [key, value] of Object.entries(results)) {
-        inline += `${key}=${value} `
+        inline += `${key}="${value}" `
       }
-      inline = inline.trimEnd()
+      inline = inline.trim()
 
       process.stdout.write(inline)
     // json format

--- a/src/cli/actions/get.js
+++ b/src/cli/actions/get.js
@@ -20,21 +20,32 @@ function get (key) {
     envs = this.envs
   }
 
-  const value = main.get(key, envs, options.overload, process.env.DOTENV_KEY, options.all)
+  const results = main.get(key, envs, options.overload, process.env.DOTENV_KEY, options.all)
 
-  if (typeof value === 'object' && value !== null) {
-    let space = 0
-    if (options.prettyPrint) {
-      space = 2
+  if (typeof results === 'object' && results !== null) {
+    // inline shell format - env $(dotenvx get --format shell) your-command
+    if (options.format === 'shell') {
+      let inline = ''
+      for (const [key, value] of Object.entries(results)) {
+        inline += ` ${key}=${value}`
+      }
+
+      process.stdout.write(inline)
+    // json format
+    } else {
+      let space = 0
+      if (options.prettyPrint) {
+        space = 2
+      }
+
+      process.stdout.write(JSON.stringify(results, null, space))
     }
-
-    process.stdout.write(JSON.stringify(value, null, space))
   } else {
-    if (value === undefined) {
+    if (results === undefined) {
       process.stdout.write('')
       process.exit(1)
     } else {
-      process.stdout.write(value)
+      process.stdout.write(results)
     }
   }
 }

--- a/src/cli/actions/get.js
+++ b/src/cli/actions/get.js
@@ -27,8 +27,9 @@ function get (key) {
     if (options.format === 'shell') {
       let inline = ''
       for (const [key, value] of Object.entries(results)) {
-        inline += ` ${key}=${value}`
+        inline += `${key}=${value} `
       }
+      inline = inline.trimEnd()
 
       process.stdout.write(inline)
     // json format

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -75,6 +75,7 @@ program.command('get')
   .option('--convention <name>', 'load a .env convention (available conventions: [\'nextjs\'])')
   .option('-a, --all', 'include all machine envs as well')
   .option('-pp, --pretty-print', 'pretty print output')
+  .option('--format <type>', 'format of the output (json, shell)', 'json')
   .action(function (...args) {
     this.envs = envs
 

--- a/tests/cli/actions/get.test.js
+++ b/tests/cli/actions/get.test.js
@@ -54,7 +54,6 @@ t.test('get --format shell', ct => {
   ct.end()
 })
 
-
 t.test('get --pretty-print', ct => {
   const optsStub = sinon.stub().returns({ prettyPrint: true })
   const fakeContext = { opts: optsStub }

--- a/tests/cli/actions/get.test.js
+++ b/tests/cli/actions/get.test.js
@@ -39,6 +39,22 @@ t.test('get KEY', ct => {
   ct.end()
 })
 
+t.test('get --format shell', ct => {
+  const optsStub = sinon.stub().returns({ format: 'shell' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(main, 'get').returns({ HELLO: 'World' })
+
+  const stdout = capcon.interceptStdout(() => {
+    get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'main.get() called')
+  t.equal(stdout, 'HELLO=World')
+
+  ct.end()
+})
+
+
 t.test('get --pretty-print', ct => {
   const optsStub = sinon.stub().returns({ prettyPrint: true })
   const fakeContext = { opts: optsStub }

--- a/tests/cli/actions/get.test.js
+++ b/tests/cli/actions/get.test.js
@@ -49,7 +49,7 @@ t.test('get --format shell', ct => {
   })
 
   t.ok(stub.called, 'main.get() called')
-  t.equal(stdout, 'HELLO=World')
+  t.equal(stdout, 'HELLO="World"')
 
   ct.end()
 })


### PR DESCRIPTION
ran into an edge case with systemd and puma that i cannot yet solve - related to `dotenvx run -- bundle exec puma` (but only with systemd). strange.

this feature gives a workaround by foregoing the wrapping run for `env`:

```
$ env $(dotenvx get --format shell) bundle exec puma
```

that will work with systemd