### PR TITLE
Use `options.stdio` instead of `2>os.devNull`

### DIFF
--- a/src/lib/services/run.js
+++ b/src/lib/services/run.js
@@ -286,7 +286,7 @@ class Run {
     } catch (_e) {
       try {
         // if installed as binary cli
-        privateKey = childProcess.execSync(`dotenvx-pro keypair ${privateKeyName} -f ${envFilepath} 2>/dev/null`).toString().trim()
+        privateKey = childProcess.execSync(`dotenvx-pro keypair ${privateKeyName} -f ${envFilepath}`, {stdio: ['pipe', 'pipe', 'ignore']}).toString().trim()
       } catch (_e) {
         // fallback to local KeyPair - smart enough to handle process.env, .env.keys, etc
         privateKey = new Keypair(envFilepath, privateKeyName).run()


### PR DESCRIPTION
Use `options.stdio` instead of `2>os.devNull`
to suppress stderr output for dotenvx-pro cmd.

https://nodejs.org/api/os.html#osdevnull