### PR TITLE
TS interface fix

### DIFF
--- a/src/lib/main.d.ts
+++ b/src/lib/main.d.ts
@@ -203,10 +203,10 @@ export function ls(
  */
 export function get(
   key?: string,
-  envs: string[] = [],
-  overload = false,
-  DOTENV_KEY = '',
-  all = false
+  envs?: string[],
+  overload?: boolean,
+  DOTENV_KEY?: string,
+  all?: boolean
 ): Record<string, string | undefined> | string | undefined;
 
 export type SetOutput = {


### PR DESCRIPTION
Since TS version 5.3 (https://github.com/microsoft/TypeScript/issues/56525) it is not allowed default values in interface definition. It causes error you can see on the fig. So I suggest this patch.

![image](https://github.com/user-attachments/assets/e2d9568c-6198-40cf-9216-13bae459e203)
