### PR TITLE
Fix "command not found" error in precommit script

### DIFF
--- a/src/lib/helpers/installPrecommitHook.js
+++ b/src/lib/helpers/installPrecommitHook.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 const HOOK_SCRIPT = `#!/bin/sh
 
-if ! command -v dotenvx &> /dev/null
+if ! command -v dotenvx 2>&1 >/dev/null
 then
   echo "[dotenvx][precommit] 'dotenvx' command not found"
   echo "[dotenvx][precommit] ? install it with [brew install dotenvx/brew/dotenvx]"


### PR DESCRIPTION
The `&>` output redirection is [not POSIX compliant][SC3020], and causes a "command not found" on some systems (e.g. Ubuntu 20.04) even when `dotenvx` is installed:

  ```console
  $ git commit -m 'my message'
  [dotenvx][precommit] 'dotenvx' command not found
  [dotenvx][precommit] ? install it with [brew install dotenvx/brew/dotenvx]
  [dotenvx][precommit] ? other install options [https://dotenvx.com/docs/install]
  /my/path/to/dotenvx
  ```

This commit changes the output redirection to use `2>&1`, fixing the issue.

[SC3020]: https://www.shellcheck.net/wiki/SC3020
