### PR TITLE
Ignore `.env.local` only when `NODE_ENV` is `test`

### DIFF
--- a/src/lib/helpers/conventions.js
+++ b/src/lib/helpers/conventions.js
@@ -1,26 +1,14 @@
 function conventions (convention) {
   if (convention === 'nextjs') {
     const nodeEnv = process.env.NODE_ENV || 'development'
+    const canonicalEnv = ['development', 'test', 'production'].includes(nodeEnv) && nodeEnv
 
-    const envs = []
-
-    if (['development', 'test', 'production'].includes(nodeEnv)) {
-      envs.push({ type: 'envFile', value: `.env.${nodeEnv}.local` })
-    }
-
-    if (['development', 'production'].includes(nodeEnv)) {
-      envs.push({ type: 'envFile', value: '.env.local' })
-    }
-
-    if (['development', 'test', 'production'].includes(nodeEnv)) {
-      envs.push({ type: 'envFile', value: `.env.${nodeEnv}` })
-    }
-
-    if (['development', 'test', 'production'].includes(nodeEnv)) {
-      envs.push({ type: 'envFile', value: '.env' })
-    }
-
-    return envs
+    return [
+      canonicalEnv && { type: 'envFile', value: `.env.${canonicalEnv}.local` },
+      canonicalEnv !== 'test' && { type: 'envFile', value: '.env.local' },
+      canonicalEnv && { type: 'envFile', value: `.env.${canonicalEnv}` },
+      { type: 'envFile', value: '.env' }
+    ].filter(Boolean)
   } else {
     throw new Error(`INVALID_CONVENTION: '${convention}'. permitted conventions: ['nextjs']`)
   }

--- a/tests/lib/helpers/conventions.test.js
+++ b/tests/lib/helpers/conventions.test.js
@@ -46,3 +46,20 @@ t.test('#conventions (process.env.NODE_ENV is test)', ct => {
 
   ct.end()
 })
+
+t.test('#conventions (process.env.NODE_ENV is unrecognized)', ct => {
+  const originalNodeEnv = process.env.NODE_ENV
+
+  process.env.NODE_ENV = 'unrecognized'
+
+  const envs = conventions('nextjs')
+
+  ct.same(envs, [
+    { type: 'envFile', value: '.env.local' },
+    { type: 'envFile', value: '.env' }
+  ])
+
+  process.env.NODE_ENV = originalNodeEnv
+
+  ct.end()
+})


### PR DESCRIPTION
Prior to this commit, when using `--convention=nextjs` and a non-canonical `NODE_ENV`, `dotenvx` would ignore an existing `.env.local` file.

This commit causes `dotenvx` to ignore `.env.local` only when `NODE_ENV` is `test`.

---

This is an edge case and probably not a big deal, but it seemed unintended to me considering [the way it is implemented in Next.js](https://github.com/vercel/next.js/blob/ca5f29d81b011c3a01e2372118b29836f1df0fa7/packages/next-env/index.ts#L134-L142).  An alternative would be to keep the logic the same, but log a warning when `NODE_ENV` is non-canonical.

By the way, if the previous code style (`if` + `push`) is preferred, just let me know.  I can switch back to it.
