### PR TITLE
rm misleading log msg re: appending to gitignore

### DIFF
--- a/src/cli/actions/encrypt.js
+++ b/src/cli/actions/encrypt.js
@@ -62,11 +62,6 @@ function encrypt () {
       for (const processedEnv of processedEnvs) {
         if (processedEnv.privateKeyAdded) {
           logger.success(`✔ key added to .env.keys (${processedEnv.privateKeyName})`)
-
-          if (!isIgnoringDotenvKeys()) {
-            logger.help2('ℹ add .env.keys to .gitignore: [echo ".env.keys" >> .gitignore]')
-          }
-
           logger.help2(`ℹ run [${processedEnv.privateKeyName}='${processedEnv.privateKey}' dotenvx run -- yourcommand] to test decryption locally`)
         }
       }


### PR DESCRIPTION
I'm trying out `dotenvx` and ran this command:
```sh
$ dotenvx encrypt

✔ encrypted (.env)
✔ key added to .env.keys (DOTENV_PRIVATE_KEY)
ℹ add .env.keys to .gitignore: [echo ".env.keys" >> .gitignore]

$ git status
Untracked files:
	.env
	.env.keys
	
$ ls -a

.env
.env.keys
. git
Makefile
README.md
```

and deduced that the final log (`echo ".env.keys" >> .gitignore`) is not happening.

This seems to be purposeful (https://github.com/dotenvx/dotenvx/pull/45), just figured better to align the logs with the actual execution.