### PR TITLE
Proposal: Use `export` to mark unencrypted values as safe

### DIFF
--- a/src/lib/helpers/isFullyEncrypted.js
+++ b/src/lib/helpers/isFullyEncrypted.js
@@ -1,13 +1,12 @@
-const dotenv = require('dotenv')
-
+const parseEnv = require('./parseEnv')
 const isEncrypted = require('./isEncrypted')
 const isPublicKey = require('./isPublicKey')
 
 function isFullyEncrypted (src) {
-  const parsed = dotenv.parse(src)
+  const parsed = parseEnv(src)
 
-  for (const [key, value] of Object.entries(parsed)) {
-    const result = isEncrypted(value) || isPublicKey(key, value)
+  for (const { key, value, isExported } of parsed) {
+    const result = isExported || isEncrypted(value) || isPublicKey(key, value)
     if (!result) {
       return false
     }

--- a/src/lib/helpers/parseEnv.js
+++ b/src/lib/helpers/parseEnv.js
@@ -1,0 +1,44 @@
+const LINE = /(?:^|^)\s*(?<exported>export\s+)?(?<key>[\w.-]+)(?:\s*=\s*?|:\s+?)(?<value>\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
+
+// Parse src into an array of objects
+function parseEnv (src) {
+  const objects = []
+
+  // Convert buffer to string
+  let lines = src.toString()
+
+  // Convert line breaks to same format
+  lines = lines.replace(/\r\n?/mg, '\n')
+
+  let match
+  while ((match = LINE.exec(lines)) != null) {
+    let { exported, key, value } = match.groups
+
+    // Default undefined or null to empty string
+    value ??= ''
+
+    // Remove whitespace
+    value = value.trim()
+
+    // Check if double quoted
+    const maybeQuote = value[0]
+
+    // Remove surrounding quotes
+    value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
+
+    const quote = value[0] === maybeQuote ? '' : maybeQuote
+
+    // Expand newlines if double quoted
+    if (quote === '"') {
+      value = value.replace(/\\n/g, '\n')
+      value = value.replace(/\\r/g, '\r')
+    }
+
+    // Add to array
+    objects.push({ key, value, quote, isExported: !!exported })
+  }
+
+  return objects
+}
+
+module.exports = parseEnv

--- a/src/lib/helpers/quotes.js
+++ b/src/lib/helpers/quotes.js
@@ -1,36 +1,9 @@
-const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
+const parseEnv = require('./parseEnv')
 
 function quotes (src) {
-  const obj = {}
-  // Convert buffer to string
-  let lines = src.toString()
-
-  // Convert line breaks to same format
-  lines = lines.replace(/\r\n?/mg, '\n')
-
-  let match
-  while ((match = LINE.exec(lines)) != null) {
-    const key = match[1]
-
-    // Default undefined or null to empty string
-    let value = (match[2] || '')
-
-    // Remove whitespace
-    value = value.trim()
-
-    // Check if double quoted
-    const maybeQuote = value[0]
-
-    value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
-
-    if (maybeQuote === value[0]) {
-      obj[key] = ''
-    } else {
-      obj[key] = maybeQuote
-    }
-  }
-
-  return obj
+  return Object.fromEntries(
+    parseEnv(src).map(({ key, quote }) => [key, quote])
+  )
 }
 
 module.exports = quotes

--- a/tests/.env.export
+++ b/tests/.env.export
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-export KEY=value
+ENCRYPT=value
+export EXPOSE=value

--- a/tests/lib/services/encrypt.test.js
+++ b/tests/lib/services/encrypt.test.js
@@ -362,16 +362,17 @@ t.test('#run (finds .env.export file with exported key)', ct => {
   } = new Encrypt(envs).run()
 
   const p1 = processedEnvs[0]
-  ct.same(p1.keys, ['KEY'])
+  ct.same(p1.keys, ['ENCRYPT'])
   ct.same(p1.envFilepath, 'tests/.env.export')
   ct.same(changedFilepaths, ['tests/.env.export'])
   ct.same(unchangedFilepaths, [])
 
   const parsed = dotenv.parse(p1.envSrc)
 
-  ct.same(Object.keys(parsed), ['DOTENV_PUBLIC_KEY_EXPORT', 'KEY'])
+  ct.same(Object.keys(parsed), ['DOTENV_PUBLIC_KEY_EXPORT', 'ENCRYPT', 'EXPOSE'])
   ct.ok(parsed.DOTENV_PUBLIC_KEY_EXPORT, 'DOTENV_PUBLIC_KEY should not be empty')
-  ct.match(parsed.KEY, /^encrypted:/, 'KEY should start with "encrypted:"')
+  ct.match(parsed.ENCRYPT, /^encrypted:/, 'ENCRYPT should start with "encrypted:"')
+  ct.match(parsed.EXPOSE, 'value', 'EXPOSE should not be encrypted')
 
   const output = `#!/usr/bin/env bash
 #/-------------------[DOTENV_PUBLIC_KEY]--------------------/
@@ -381,7 +382,8 @@ t.test('#run (finds .env.export file with exported key)', ct => {
 DOTENV_PUBLIC_KEY_EXPORT="${parsed.DOTENV_PUBLIC_KEY_EXPORT}"
 
 # .env.export
-export KEY=${parsed.KEY}
+ENCRYPT=${parsed.ENCRYPT}
+export EXPOSE=${parsed.EXPOSE}
 `
   ct.same(p1.envSrc, output)
 


### PR DESCRIPTION
Encrypting env files is a killer feature of dotenvx, but viewing and editing fully encrypted env files can be cumbersome.  Selectively encrypting values with `dotenvx encrypt -k` makes viewing and editing significantly easier, but the `dotenvx ext precommit` hook forbids any unencrypted values because it doesn't know which values should be encrypted.

This PR proposes using the `export` keyword to mark unencrypted values as safe.  This would allow the pre-commit hook to safely handle selectively encrypted env files.  The pre-commit hook could even auto-encrypt env files and preserve their selective encryption.

The envisioned workflow would be something like:

1. Add or edit a value in the env file.

2. If the value is safe to expose, add the `export` keyword.  Otherwise, omit the `export` keyword.

3. Simply run `dotenvx encrypt` (without the `-k` / `-ek` options).  dotenvx will encrypt only the values that do not have the `export` keyword.

4. Commit the file to git; the pre-commit hook passes.


#### TODO:

- [ ] __Integrate with `dotenvx encrypt -k`.__

    Remove `export` (if present) from the specified keys.

- [ ] __Integrate with `dotenvx encrypt -ek`.__

    Add `export` (if not present) to the specified keys.

- [ ] __Add `dotenvx encrypt --all`.__

    Removes all `export`s and encrypts all values.  Can use this when deriving an env file from a shell script.

- [ ] __Warn when `dotenvx decrypt` encounters an encrypted value that also has `export`.__

    Let the user know that if they re-encrypt the file using the default behavior, those values will not be re-encrypted.

- [ ] __Modify pre-commit hook to automatically encrypt?__

    Instead of erroring on unencrypted values, automatically encrypt them.  Probably save this for a follow-up PR.

- [ ] __Tests__

- [ ] __Document in README__
