### PR TITLE
Fix Readme dedicated to .env.ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,7 +867,7 @@ More examples
 
   ```sh
   $ touch .env.ci
-  $ dotenvx set HELLO "ci encrypted" -f .env.production
+  $ dotenvx set HELLO "ci encrypted" -f .env.ci
   $ echo "console.log('Hello ' + process.env.HELLO)" > index.js
 
   # check .env.keys for your privateKey


### PR DESCRIPTION
The part dedicated to .env.ci was referencing the .env.production file.