### PR TITLE
Remove --cached flag from precommit hook

### DIFF
--- a/src/lib/services/precommit.js
+++ b/src/lib/services/precommit.js
@@ -88,7 +88,7 @@ class Precommit {
 
   _isFileToBeCommitted (filePath) {
     try {
-      const output = childProcess.execSync('git diff --name-only').toString()
+      const output = childProcess.execSync('git diff HEAD --name-only').toString()
       const files = output.split('\n')
 
       return files.includes(filePath)

--- a/src/lib/services/precommit.js
+++ b/src/lib/services/precommit.js
@@ -88,7 +88,7 @@ class Precommit {
 
   _isFileToBeCommitted (filePath) {
     try {
-      const output = childProcess.execSync('git diff --cached --name-only').toString()
+      const output = childProcess.execSync('git diff --name-only').toString()
       const files = output.split('\n')
 
       return files.includes(filePath)


### PR DESCRIPTION
This is a proposal to remove the usage of the `--cached` flag, and include the `HEAD` argument in the `git diff` command
during `dotenvx ext precommit`.

The primary reason for the `precommit` hook is to protect `.env` files from beings accidentally committed in an
unencrypted state and potentially leaking sensitive information such as API keys, passwords, etc. It makes sense to take
the maximum precautions possible to ensure that the `precommit` hook is as effective as possible.


From the `git diff` documentation:

```
git diff [<options>] --cached [--merge-base] [<commit>] [--] [<path>...]
   This form is to view the changes you staged for the next commit relative to the named <commit>. Typically you would 
   want comparison with the latest commit, so if you do not give <commit>, it defaults to HEAD. If HEAD does not exist 
   (e.g. unborn branches) and <commit> is not given, it shows all staged changes. --staged is a synonym of --cached.

   If --merge-base is given, instead of using <commit>, use the merge base of <commit> and HEAD.  git diff --cached 
   --merge-base A is equivalent to git diff --cached $(git merge-base A HEAD).
```

Intuitively, I would expect that a `precommit` hook would check all files which would be commit in the case of a `git
commit`, but this is not the case as the `--cached` flag only returns files which are already staged for commit. The 
implications of this are that unencrypted `.env` files which are NOT ignored by a `.gitignore` and have NOT been staged
with `git add` will not be caught by the `precommit` hook, and give a false sense of security to the developer.

It's common for a developer workflow to use one of the following commands to commit changes, neither of which would be protected by the current `precommit` hook:

```
git commit <dir> -m "<commit msg>"
git commit -am "<commit msg>"
```

From the `git diff` documentation:

```
Various ways to check your working tree

       $ git diff            (1)
       $ git diff --cached   (2)
       $ git diff HEAD       (3)
       $ git diff AUTO_MERGE (4)

   1.   Changes in the working tree not yet staged for the next
        commit.
   2.   Changes between the index and your last commit; what you would
        be committing if you run git commit without -a option.
   3.   Changes in the working tree since your last commit; what you
        would be committing if you run git commit -a
   4.   Changes in the working tree you’ve made to resolve textual
        conflicts so far.
```

Consideing the above options, it would provide maximum protection without much downside to use `git diff HEAD` to ensure that all files which would be committed by `git commit -a` variant are checked by the `precommit` hook.
