### PR TITLE
Update README.md - correcting esm export example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install @dotenvx/dotenvx --save
 ```js
 // index.js
 require('@dotenvx/dotenvx').config()
-// or import('@dotenvx/dotenvx/config') // for esm
+// or import '@dotenvx/dotenvx/config' // for esm
 
 console.log(`Hello ${process.env.HELLO}`)
 ```


### PR DESCRIPTION
Correcting the esm export example.

```ts
import '@dotenvx/dotenvx/config'
```
instead of 
```ts
import('@dotenvx/dotenvx/config')
```