### PR TITLE
git precommit supports npm local installation

### DIFF
--- a/src/lib/helpers/installPrecommitHook.js
+++ b/src/lib/helpers/installPrecommitHook.js
@@ -3,15 +3,19 @@ const path = require('path')
 
 const HOOK_SCRIPT = `#!/bin/sh
 
-if ! command -v dotenvx 2>&1 >/dev/null
+if command -v dotenvx 2>&1 >/dev/null
 then
+  dotenvx ext precommit
+elif [ -x  node_modules/.bin/dotenvx ]
+then
+  npx dotenvx ext precommit
+else
   echo "[dotenvx][precommit] 'dotenvx' command not found"
   echo "[dotenvx][precommit] ? install it with [curl -fsS https://dotenvx.sh | sh]"
   echo "[dotenvx][precommit] ? other install options [https://dotenvx.com/docs/install]"
   exit 1
 fi
-
-dotenvx ext precommit`
+`
 
 class InstallPrecommitHook {
   constructor () {


### PR DESCRIPTION
I have installed dotenvx using npm locally (`npm install dotenvx`); And tried to use the precommit extension:

```bash
$ npx dotenvx ext precommit --install
$ git add *.env # for test purpose
$ git commit ...
```

But got:

```bash
[dotenvx][precommit] 'dotenvx' command not found
[dotenvx][precommit] ? install it with [curl -fsS https://dotenvx.sh | sh]
[dotenvx][precommit] ? other install options [https://dotenvx.com/docs/install]
```

After inspecting the source I found that the file loading the script as a git hook (`installPrecommitHook.js`) is only expecting the dotenvx binary to be in system path, so I added the necessary lines to use the binary in `node_modules/.bin` if necessary --making possible to run `npx dotenvx precommit`.