### PR TITLE
export cli folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     },
     "./config": "./src/lib/config.js",
     "./config.js": "./src/lib/config.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./cli/*": "./src/cli/*"
   },
   "bin": {
     "dotenvx": "./src/cli/dotenvx.js",


### PR DESCRIPTION
Why?

Before adding `exports` to the `package.json`, I have a file import the cli like this `import '@dotenvx/dotenvx/src/cli/dotenvx.js';`

But after adding the `exports` field, it reports error: `Package subpath './src/cli/dotenvx.js' is not defined by "exports"`

So, I add a `cli exports` in this pr, so that I can now import the cli like this `import '@dotenvx/dotenvx/cli/dotenvx.js';` without error.