### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,7 +306,7 @@ FOO=${FOO}bar
 
 ### Changed
 
-* for `--convention nextjs` ingnore `.env.local` for TEST environment ([#425](https://github.com/dotenvx/dotenvx/pull/425))
+* for `--convention nextjs` ignore `.env.local` for TEST environment ([#425](https://github.com/dotenvx/dotenvx/pull/425))
 * for `precommit` redirect missing `dotenvx` command using POSIX compliant redirection ([#424](https://github.com/dotenvx/dotenvx/pull/424))
 * make parent `dotenvx help` command less noisy by removing `[options]`. run `dotenvx COMMAND -h` to list all available options like always ([#429](https://github.com/dotenvx/dotenvx/pull/429))
 
@@ -847,7 +847,7 @@ Learn more at [https://dotenvx.com/docs/quickstart#add-encryption]
 
 ### Added
 
-* Support encryption replacemnt of multiline values ([#220](https://github.com/dotenvx/dotenvx/pull/220))
+* Support encryption replacement of multiline values ([#220](https://github.com/dotenvx/dotenvx/pull/220))
 
 ## 0.40.0
 
@@ -900,7 +900,7 @@ Further notes:
 
 * `DOTENV_PUBLIC_KEY` lives in the `.env` file. You can safely share this with whomever you wish.
 * `DOTENV_PRIVATE_KEY` lives in your `.env.keys` file. Share this only with those you trust to decrypt your secrets.
-* If using encrypted `.env` files like this it is safe to commmit them to source code. This makes reviewing PRs that contain secrets much easier.
+* If using encrypted `.env` files like this it is safe to commit them to source code. This makes reviewing PRs that contain secrets much easier.
 * Tell your contributors to contribute a secret using the command `dotenvx set HELLO world --encrypt`.
 * Set your `DOTENV_PRIVATE_KEY` on your server to decrypt these values using `dotenvx run -- yourcommand`
 * You can repeat all this per environment by modifying your set command to `dotenvx set HELLO production -f .env.production --encrypt` (for example)

--- a/README.md
+++ b/README.md
@@ -1508,7 +1508,7 @@ Advanced CLI commands.
   </details>
 * <details><summary>`decrypt -ek`</summary><br>
 
-  Decrypt the contents inside an encrypted `.env` file except for an exluded key.
+  Decrypt the contents inside an encrypted `.env` file except for an excluded key.
 
   ```sh
   $ echo "HELLO=World\nHOLA=Mundo" > .env
@@ -1606,7 +1606,7 @@ Advanced CLI commands.
   </details>
 * <details><summary>`keypair --format shell`</summary><br>
 
-  Print a shell formatted reponse of public/private keys.
+  Print a shell formatted response of public/private keys.
 
   ```sh
   $ echo "HELLO=World" > .env
@@ -1757,7 +1757,7 @@ Advanced CLI commands.
   </details>
 * <details><summary>`rotate -ek`</summary><br>
 
-  Rotate the encrypted contents inside an encrypted `.env` file except for an exluded key.
+  Rotate the encrypted contents inside an encrypted `.env` file except for an excluded key.
 
   ```sh
   $ echo "HELLO=World\nHOLA=Mundo" > .env
@@ -2212,7 +2212,7 @@ Use dotenvx directly in code.
   </details>
 * <details><summary>`set(KEY, value)`</summary><br>
 
-  Programatically set an environment variable. 
+  Programmatically set an environment variable. 
 
   ```js
   // index.js
@@ -2223,7 +2223,7 @@ Use dotenvx directly in code.
   </details>
 * <details><summary>`get(KEY)` - <i>Decryption at Access</i></summary><br>
 
-  Programatically get an environment variable at access/runtime.
+  Programmatically get an environment variable at access/runtime.
 
   ```js
   // index.js

--- a/esbuild.js
+++ b/esbuild.js
@@ -71,7 +71,7 @@ async function main () {
     await printSize(outfile)
   }
 
-  // create main patched packege.json
+  // create main patched package.json
   cleanPkgJson(pkgJson)
 
   pkgJson.scripts = {

--- a/src/cli/commands/ext.js
+++ b/src/cli/commands/ext.js
@@ -61,7 +61,7 @@ ext.command('scan')
   .description('scan for leaked secrets')
   .action(require('./../actions/ext/scan'))
 
-// overide helpInformation to hide dynamic commands
+// override helpInformation to hide dynamic commands
 ext.helpInformation = function () {
   const originalHelp = Command.prototype.helpInformation.call(this)
   const lines = originalHelp.split('\n')

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -219,7 +219,7 @@ program.command('precommit')
     precommitAction.apply(this, args)
   })
 
-// overide helpInformation to hide DEPRECATED and 'ext' commands
+// override helpInformation to hide DEPRECATED and 'ext' commands
 program.helpInformation = function () {
   const originalHelp = Command.prototype.helpInformation.call(this)
   const lines = originalHelp.split('\n')

--- a/src/lib/services/precommit.js
+++ b/src/lib/services/precommit.js
@@ -46,7 +46,7 @@ class Precommit {
       dotenvFiles.forEach(file => {
         count += 1
 
-        // check if file is going to be commited
+        // check if file is going to be committed
         if (this._isFileToBeCommitted(file)) {
           // check if that file is being ignored
           if (ig.ignores(file)) {

--- a/tests/cli/actions/run.test.js
+++ b/tests/cli/actions/run.test.js
@@ -672,7 +672,7 @@ t.test('run - envFile (missing command arguments after --)', async ct => {
   ct.end()
 })
 
-t.test('run - envFile (ambigious arguments, missing --)', async ct => {
+t.test('run - envFile (ambiguous arguments, missing --)', async ct => {
   const optsStub = sinon.stub().returns({ envFile: ['.env.production'] })
   const fakeContext = { opts: optsStub, args: [], envs: [] }
   sinon.stub(process, 'argv').value(['node', 'dotenvx', 'run', '-f', '.env.production', 'echo', ''])
@@ -713,7 +713,7 @@ t.test('run - envFile (ambigious arguments, missing --)', async ct => {
   ct.end()
 })
 
-t.test('run - envFile (ambigious arguments, missing -- and envFile is empty)', async ct => {
+t.test('run - envFile (ambiguous arguments, missing -- and envFile is empty)', async ct => {
   const optsStub = sinon.stub().returns({ envFile: [] })
   const fakeContext = { opts: optsStub, args: [], envs: [] }
   sinon.stub(process, 'argv').value(['node', 'dotenvx', 'run', '-f', '.env', 'echo', ''])

--- a/tests/e2e/ext.test.js
+++ b/tests/e2e/ext.test.js
@@ -18,10 +18,10 @@ function execShell (commands) {
 t.test('ext', ct => {
   const output = execShell(`${dotenvx} ext`)
 
-  t.match(output, /genexample/, 'shoud say genexample')
-  t.match(output, /gitignore/, 'shoud say gitignore')
-  t.match(output, /prebuild/, 'shoud say prebuild')
-  t.match(output, /precommit/, 'shoud say precommit')
+  t.match(output, /genexample/, 'should say genexample')
+  t.match(output, /gitignore/, 'should say gitignore')
+  t.match(output, /prebuild/, 'should say prebuild')
+  t.match(output, /precommit/, 'should say precommit')
 
   ct.end()
 })
@@ -29,7 +29,7 @@ t.test('ext', ct => {
 t.test('ext missing', ct => {
   const output = execShell(`${dotenvx} ext missing`)
 
-  t.match(output, "error: unknown command 'missing'", 'shoud say installation needed')
+  t.match(output, "error: unknown command 'missing'", 'should say installation needed')
 
   ct.end()
 })
@@ -37,8 +37,8 @@ t.test('ext missing', ct => {
 t.test('ext vault', ct => {
   const output = execShell(`${dotenvx} ext vault`)
 
-  t.match(output, /\[INSTALLATION_NEEDED\] install dotenvx-ext-vault to use \[dotenvx ext vault\] commands/, 'shoud say installation needed')
-  t.match(output, /see installation instructions/, 'shoud say see installation instructions')
+  t.match(output, /\[INSTALLATION_NEEDED\] install dotenvx-ext-vault to use \[dotenvx ext vault\] commands/, 'should say installation needed')
+  t.match(output, /see installation instructions/, 'should say see installation instructions')
 
   ct.end()
 })

--- a/tests/lib/main.test.js
+++ b/tests/lib/main.test.js
@@ -211,7 +211,7 @@ t.test('config monorepo/apps/backend/.env', ct => {
   ct.end()
 })
 
-t.test('config monorepo/apps/backend/.env alredy set', ct => {
+t.test('config monorepo/apps/backend/.env already set', ct => {
   const processEnv = {
     HELLO: 'world'
   }
@@ -230,7 +230,7 @@ t.test('config monorepo/apps/backend/.env alredy set', ct => {
   ct.end()
 })
 
-t.test('config monorepo/apps/backend/.env alredy set --overload', ct => {
+t.test('config monorepo/apps/backend/.env already set --overload', ct => {
   const processEnv = {
     HELLO: 'world'
   }

--- a/tests/lib/services/genexample.test.js
+++ b/tests/lib/services/genexample.test.js
@@ -122,14 +122,14 @@ t.test('#run (missing env files)', ct => {
   ct.end()
 })
 
-t.test('#run (non-existant .env file)', ct => {
+t.test('#run (non-existent .env file)', ct => {
   try {
-    new Genexample('tests/monorepo/apps/frontend', ['.env.nonexistant']).run()
+    new Genexample('tests/monorepo/apps/frontend', ['.env.nonexistent']).run()
     ct.fail('should have raised an error but did not')
   } catch (error) {
     ct.equal(error.code, 'MISSING_ENV_FILE')
-    ct.equal(error.message, `[MISSING_ENV_FILE] missing .env.nonexistant file (${path.resolve('tests/monorepo/apps/frontend/.env.nonexistant')})`)
-    ct.equal(error.help, '? add it with [echo "HELLO=World" > .env.nonexistant] and then run [dotenvx genexample]')
+    ct.equal(error.message, `[MISSING_ENV_FILE] missing .env.nonexistent file (${path.resolve('tests/monorepo/apps/frontend/.env.nonexistent')})`)
+    ct.equal(error.help, '? add it with [echo "HELLO=World" > .env.nonexistent] and then run [dotenvx genexample]')
   }
 
   ct.end()

--- a/tests/lib/services/prebuild.test.js
+++ b/tests/lib/services/prebuild.test.js
@@ -116,7 +116,7 @@ t.test('#run (dockerignore is not ignore .env.keys file and should)', ct => {
   ct.end()
 })
 
-t.test('#run (dockerignore is not ignore .env.production file and should) AND isFileToBeCommited raises an error (should default to true on the filename)', ct => {
+t.test('#run (dockerignore is not ignore .env.production file and should) AND isFileToBeCommitted raises an error (should default to true on the filename)', ct => {
   sinon.stub(Ls.prototype, 'run').returns(['.env.production'])
   childProcess.execSync.throws(new Error('Mock Error'))
   const readFileXStub = sinon.stub(fsx, 'readFileX')

--- a/tests/lib/services/run.test.js
+++ b/tests/lib/services/run.test.js
@@ -768,7 +768,7 @@ options="$\{options} optA"
 configX=blah
 # config2 definitions
 options="$\{options} optB optC $\{configX:+optX}"
-# config3 defintions
+# config3 definitions
 options="$\{options} optD"`
   const envs = [
     { type: 'env', value: src }


### PR DESCRIPTION
Found via `codespell -L mot,thar,cant` and
`typos --hidden --format brief`