### PR TITLE
fix: check only staged files for precommit hook

### DIFF
--- a/src/lib/services/precommit.js
+++ b/src/lib/services/precommit.js
@@ -116,7 +116,7 @@ class Precommit {
         return true
       }
 
-      const output = childProcess.execSync('git diff HEAD --name-only').toString()
+      const output = childProcess.execSync('git diff HEAD --name-only --cached').toString()
       const files = output.split('\n')
       return files.includes(filePath)
     } catch (error) {


### PR DESCRIPTION
Hi,
I just integrated dotenvx into our project and noticed that the precommit hook was failing on me because I had unencrypted values in my `.env`.

This is absolutely intended, because I'm debugging stuff using a different API Key. But I wasn't able to commit other stuff because the precommit hook detects a diff in my worktree that is not staged for the commit.

I could workaround this by just stashing the diff in `.env`, make the commit and then unstash again, but I think improving the detection here makes things a lot easier.