### PR TITLE
npm audit fix: tar-fs 2.0.0 -> 2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10272,9 +10272,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Updated `tar-fs` from 2.0.0 to 2.1.3:

```sh-session
> npm audit
# npm audit report

tar-fs  2.0.0 - 2.1.3
Severity: high
tar-fs has a symlink validation bypass if destination directory is predictable with a specific tarball - https://github.com/advisories/GHSA-vj76-c3g6-qr5v
fix available via `npm audit fix`
node_modules/tar-fs

1 high severity vulnerability

To address all issues, run:
  npm audit fix

> npm ls tar-fs
@dotenvx/dotenvx@1.51.0 /Development/dotenvx
└─┬ @yao-pkg/pkg@5.16.1
  ├─┬ @yao-pkg/pkg-fetch@3.5.16
  │ └── tar-fs@2.1.3
  └─┬ prebuild-install@7.1.1
    └── tar-fs@2.1.3 deduped

> npm audit fix

changed 1 package, and audited 852 packages in 2s

198 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```