### PR TITLE
Fix: test error in decryptKeyValue.js

### DIFF
--- a/src/lib/helpers/decryptKeyValue.js
+++ b/src/lib/helpers/decryptKeyValue.js
@@ -31,7 +31,7 @@ function decryptKeyValue (key, value, privateKeyName, privateKey) {
           decryptionError = new Errors({ key, privateKeyName, privateKey }).invalidPrivateKey()
         } else if (e.message === 'Unsupported state or unable to authenticate data') {
           decryptionError = new Errors({ key, privateKeyName, privateKey }).looksWrongPrivateKey()
-        } else if (e.message === 'Point of length 65 was invalid. Expected 33 compressed bytes or 65 uncompressed bytes') {
+        } else if (e.message === 'bad point: got length 65, expected compressed=33 or uncompressed=65') {
           decryptionError = new Errors({ key, privateKeyName, privateKey }).malformedEncryptedData()
         } else {
           decryptionError = new Errors({ key, privateKeyName, privateKey, message: e.message }).decryptionFailed()


### PR DESCRIPTION
## Use the test command to find this error
<img width="1533" height="864" alt="test-error-info" src="https://github.com/user-attachments/assets/581936c7-dc5d-495b-bbfd-3b4e781fa9fd" />

## Error reason
<img width="939" height="361" alt="real-error-message" src="https://github.com/user-attachments/assets/5b890de7-e1e2-44b2-9155-c1b41ac09f33" />

## Reproduction
<img width="799" height="879" alt="debug-info" src="https://github.com/user-attachments/assets/e892adce-82d4-48fc-b282-05f897353cad" />

### code 

```js
const { decrypt } = require("eciesjs");
const Errors = require("..//src/lib/helpers//errors");
const PREFIX = "encrypted:";

const privateKeyString =
  "1fc1cafa954a7a2bf0a6fbff46189c9e03e3a66b4d1133108ab9fcdb9e154b70";
const invalidEncryptedValue =
  "encrypted:ADJIvD6DxJdTcFdg1tcasYa9G1O5YVtFJs0yJgem+aGIlRJl9N1Fbq6kdPtIwfS0c6VJF4EN6H+D0JUwJ4FmoerQi0XQ4mv4AyA73KjrxVEqmSypg2InsV0e4WxdP5Qx/jVVSgxD";
const privateKey =
  "1fc1cafa954a7a2bf0a6fbff46189c9e03e3a66b4d1133108ab9fcdb9e154b70";

console.log("--- 准备解密所需的数据 ---");

const secret = Buffer.from(privateKeyString, "hex");
console.log("私钥 Buffer 已创建。");

const encoded = invalidEncryptedValue.substring("encrypted:".length);
console.log("已提取 Base64 编码部分。");

const ciphertext = Buffer.from(encoded, "base64");
console.log("密文 Buffer 已创建。");

console.log("\n--- 调用 decrypt 函数并捕获错误 ---");

try {
  const decryptedBuffer = decrypt(secret, ciphertext);

  console.log("解密成功！结果:", decryptedBuffer.toString());
} catch (e) {
  console.error("解密失败，捕获到原始错误:");

  decryptionError = new Errors({
    key: "KEY",
    privateKeyName: "DOTENV_PRIVATE_KEY",
    privateKey,
    message: e.message,
  }).decryptionFailed();

  console.log(decryptionError.message);
  console.log(decryptionError.code);
}

```

## Fix
<img width="975" height="194" alt="fix" src="https://github.com/user-attachments/assets/ae2f3615-6fa2-4cba-98de-d2752370a82f" />

## Run test result
<img width="564" height="271" alt="test-res" src="https://github.com/user-attachments/assets/99ff6ef8-415b-413c-967e-5b65ac9a5e4c" />

## suggestion
Add a similar command to filter out error messages from all test information.

```bash
"test:error": "tap run --reporter=dot --allow-empty-coverage --disable-coverage --timeout=60000",
```
