### PR TITLE
Add cross-platform support for shell expansion using $VAR and ${VAR}

### DIFF
--- a/src/lib/helpers/executeCommand.js
+++ b/src/lib/helpers/executeCommand.js
@@ -73,13 +73,11 @@ async function executeCommand (commandArgs, env) {
         }
         expandNext = false
       }
-    }
 
-    // expand environment variables in command arguments
-    for (let i = 0; i < commandArgs.length; i++) {
+      // expand environment variables in command arguments
       commandArgs[i] = expandVariables(commandArgs[i], env)
+      logger.debug(`expanding variables in process command to [${commandArgs.join(' ')}]`)
     }
-    logger.debug(`expanding variables in process command to [${commandArgs.join(' ')}]`)
 
     child = execute.execa(commandArgs[0], commandArgs.slice(1), {
       stdio: 'inherit',

--- a/src/lib/helpers/executeCommand.js
+++ b/src/lib/helpers/executeCommand.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const which = require('which')
 const execute = require('./../../lib/helpers/execute')
+const expandVariables = require('./expandVariables')
 const { logger } = require('./../../shared/logger')
 
 async function executeCommand (commandArgs, env) {
@@ -73,6 +74,12 @@ async function executeCommand (commandArgs, env) {
         expandNext = false
       }
     }
+
+    // expand environment variables in command arguments
+    for (let i = 0; i < commandArgs.length; i++) {
+      commandArgs[i] = expandVariables(commandArgs[i], env)
+    }
+    logger.debug(`expanding variables in process command to [${commandArgs.join(' ')}]`)
 
     child = execute.execa(commandArgs[0], commandArgs.slice(1), {
       stdio: 'inherit',

--- a/src/lib/helpers/expandVariables.js
+++ b/src/lib/helpers/expandVariables.js
@@ -1,0 +1,54 @@
+function expandVariables (value, env, literals = {}) {
+  const regex = /(?<!\\)\${([^{}]+)}|(?<!\\)\$([A-Za-z_][A-Za-z0-9_]*)/g
+
+  let result = value
+  let match
+
+  while ((match = regex.exec(result)) !== null) {
+    const [template, bracedExpression, unbracedExpression] = match
+    const expression = bracedExpression || unbracedExpression
+
+    // match the operators `:+`, `+`, `:-`, and `-`
+    const opRegex = /(:\+|\+|:-|-)/
+    // find first match
+    const opMatch = expression.match(opRegex)
+    const splitter = opMatch ? opMatch[0] : null
+
+    const r = expression.split(splitter)
+
+    let defaultValue
+    let val
+    const key = r.shift()
+
+    if ([':+', '+'].includes(splitter)) {
+      defaultValue = env[key] ? r.join(splitter) : ''
+      val = null
+    } else {
+      defaultValue = r.join(splitter)
+      val = env[key]
+    }
+
+    if (val) {
+      result = result.replace(template, val)
+    } else {
+      result = result.replace(template, defaultValue)
+    }
+
+    // if the result equaled what was in env then stop expanding - handle self-referential check as well
+    if (result === env[key]) {
+      break
+    }
+
+    // if the result came from what was a literal value then stop expanding
+    // BUT only if the literal value contains expansion patterns (${...} or $VAR)
+    if (literals[key] && /\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*/.test(literals[key])) {
+      break
+    }
+
+    regex.lastIndex = 0 // reset regex search position to re-evaluate after each replacement
+  }
+
+  return result
+}
+
+module.exports = expandVariables

--- a/tests/e2e/run.test.js
+++ b/tests/e2e/run.test.js
@@ -65,6 +65,7 @@ HELLO set to World
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
 expanding variables in process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello World`) // --debug
 
   ct.end()
@@ -95,6 +96,7 @@ HELLO pre-exists as local (protip: use --overload to override)
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
 expanding variables in process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello local`) // --debug
 
   ct.end()
@@ -124,6 +126,7 @@ HELLO set to World
 [dotenvx@${version}] injecting env (1) from .env.local, .env
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 expanding variables in process command to [${node} index.js]
 Hello World`) // --debug
 
@@ -181,6 +184,7 @@ HELLO pre-exists as String (protip: use --overload to override)
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
 expanding variables in process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello String`) // --debug
 
   ct.end()
@@ -211,6 +215,7 @@ HELLO set to encrypted
 [dotenvx@${version}] injecting env (2) from .env
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 expanding variables in process command to [${node} index.js]
 Hello encrypted`) // --debug
 
@@ -254,6 +259,7 @@ HELLO set to ${encrypted}
 [dotenvx@${version}] injecting env (2) from .env
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 expanding variables in process command to [${node} index.js]
 Hello ${encrypted}`) // --debug
 

--- a/tests/e2e/run.test.js
+++ b/tests/e2e/run.test.js
@@ -64,6 +64,7 @@ HELLO set to World
 [dotenvx@${version}] injecting env (1) from .env
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello World`) // --debug
 
   ct.end()
@@ -93,6 +94,7 @@ HELLO pre-exists as local (protip: use --overload to override)
 [dotenvx@${version}] injecting env (1) from .env.local, .env
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello local`) // --debug
 
   ct.end()
@@ -122,6 +124,7 @@ HELLO set to World
 [dotenvx@${version}] injecting env (1) from .env.local, .env
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello World`) // --debug
 
   ct.end()
@@ -177,6 +180,7 @@ HELLO pre-exists as String (protip: use --overload to override)
 [dotenvx@${version}] injecting env (1) from .env, and --env flag
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello String`) // --debug
 
   ct.end()
@@ -207,6 +211,7 @@ HELLO set to encrypted
 [dotenvx@${version}] injecting env (2) from .env
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello encrypted`) // --debug
 
   ct.end()
@@ -249,6 +254,7 @@ HELLO set to ${encrypted}
 [dotenvx@${version}] injecting env (2) from .env
 executing process command [${node} index.js]
 expanding process command to [${node} index.js]
+expanding variables in process command to [${node} index.js]
 Hello ${encrypted}`) // --debug
 
   ct.end()

--- a/tests/lib/helpers/executeCommand.test.js
+++ b/tests/lib/helpers/executeCommand.test.js
@@ -21,6 +21,30 @@ t.test('executeCommand - success', async ct => {
   ct.end()
 })
 
+t.test('executeCommand - expands $ variables in command args', async ct => {
+  const execaStub = sinon.stub(execute, 'execa').returns({ exitCode: 0 })
+  const processExitStub = sinon.stub(process, 'exit')
+
+  await executeCommand(['echo', '$HELLO'], { HELLO: 'World' })
+
+  ct.ok(execaStub.calledWith('echo', ['World']), 'execa called with expanded args')
+  ct.ok(processExitStub.notCalled, 'process.exit should not be called')
+
+  ct.end()
+})
+
+t.test('executeCommand - expands ${} variables in command args', async ct => {
+  const execaStub = sinon.stub(execute, 'execa').returns({ exitCode: 0 })
+  const processExitStub = sinon.stub(process, 'exit')
+
+  await executeCommand(['echo', '${HELLO'], { HELLO: 'World' })
+
+  ct.ok(execaStub.calledWith('echo', ['World']), 'execa called with expanded args')
+  ct.ok(processExitStub.notCalled, 'process.exit should not be called')
+
+  ct.end()
+})
+
 t.test('executeCommand - exitCode 1', async ct => {
   const execaStub = sinon.stub(execute, 'execa').returns({ exitCode: 1 })
   const processExitStub = sinon.stub(process, 'exit')

--- a/tests/lib/helpers/executeCommand.test.js
+++ b/tests/lib/helpers/executeCommand.test.js
@@ -5,6 +5,8 @@ const { logger } = require('../../../src/shared/logger')
 
 const executeCommand = require('../../../src/lib/helpers/executeCommand')
 
+/* eslint-disable no-template-curly-in-string */
+
 t.beforeEach((ct) => {
   sinon.restore()
 })
@@ -27,7 +29,21 @@ t.test('executeCommand - expands $ variables in command args', async ct => {
 
   await executeCommand(['echo', '$HELLO'], { HELLO: 'World' })
 
-  ct.ok(execaStub.calledWith('echo', ['World']), 'execa called with expanded args')
+  ct.ok(execaStub.called, 'execa called')
+  ct.same(execaStub.getCall(0).args[1], ['World'])
+  ct.ok(processExitStub.notCalled, 'process.exit should not be called')
+
+  ct.end()
+})
+
+t.test('executeCommand - does not expand escaped $ variables in command args', async ct => {
+  const execaStub = sinon.stub(execute, 'execa').returns({ exitCode: 0 })
+  const processExitStub = sinon.stub(process, 'exit')
+
+  await executeCommand(['echo', '\\$HELLO'], { HELLO: 'World' })
+
+  ct.ok(execaStub.called, 'execa called')
+  ct.same(execaStub.getCall(0).args[1], ['\\$HELLO'])
   ct.ok(processExitStub.notCalled, 'process.exit should not be called')
 
   ct.end()
@@ -37,9 +53,23 @@ t.test('executeCommand - expands ${} variables in command args', async ct => {
   const execaStub = sinon.stub(execute, 'execa').returns({ exitCode: 0 })
   const processExitStub = sinon.stub(process, 'exit')
 
-  await executeCommand(['echo', '${HELLO'], { HELLO: 'World' })
+  await executeCommand(['echo', '${HELLO}'], { HELLO: 'World' })
 
-  ct.ok(execaStub.calledWith('echo', ['World']), 'execa called with expanded args')
+  ct.ok(execaStub.called, 'execa called')
+  ct.same(execaStub.getCall(0).args[1], ['World'])
+  ct.ok(processExitStub.notCalled, 'process.exit should not be called')
+
+  ct.end()
+})
+
+t.test('executeCommand - does not expand escaped ${} variables in command args', async ct => {
+  const execaStub = sinon.stub(execute, 'execa').returns({ exitCode: 0 })
+  const processExitStub = sinon.stub(process, 'exit')
+
+  await executeCommand(['echo', '\\${HELLO}'], { HELLO: 'World' })
+
+  ct.ok(execaStub.called, 'execa called')
+  ct.same(execaStub.getCall(0).args[1], ['\\${HELLO}'])
   ct.ok(processExitStub.notCalled, 'process.exit should not be called')
 
   ct.end()

--- a/tests/lib/helpers/expandVariables.test.js
+++ b/tests/lib/helpers/expandVariables.test.js
@@ -1,0 +1,146 @@
+const t = require('tap')
+const expandVariables = require('../../../src/lib/helpers/expandVariables')
+
+/* eslint-disable no-template-curly-in-string */
+
+t.test('basic variable expansion', ct => {
+  const env = { BASIC: 'expanded' }
+  const result = expandVariables('$BASIC', env)
+  ct.same(result, 'expanded')
+  ct.end()
+})
+
+t.test('braced variable expansion', ct => {
+  const env = { BASIC: 'expanded' }
+  const result = expandVariables('${BASIC}', env)
+  ct.same(result, 'expanded')
+  ct.end()
+})
+
+t.test('undefined variable becomes empty string', ct => {
+  const env = { BASIC: 'expanded' }
+  const result = expandVariables('$UNDEFINED', env)
+  ct.same(result, '')
+  ct.end()
+})
+
+t.test('default value with :- operator', ct => {
+  const env = { UNDEFINED: undefined }
+  const result = expandVariables('${UNDEFINED:-default}', env)
+  ct.same(result, 'default')
+  ct.end()
+})
+
+t.test('default value with - operator', ct => {
+  const env = { UNDEFINED: undefined }
+  const result = expandVariables('${UNDEFINED-default}', env)
+  ct.same(result, 'default')
+  ct.end()
+})
+
+t.test('default value not used when variable exists', ct => {
+  const env = { BASIC: 'expanded' }
+  const result = expandVariables('${BASIC:-default}', env)
+  ct.same(result, 'expanded')
+  ct.end()
+})
+
+t.test('alternative value with :+ operator', ct => {
+  const env = { BASIC: 'expanded' }
+  const result = expandVariables('${BASIC:+alternative}', env)
+  ct.same(result, 'alternative')
+  ct.end()
+})
+
+t.test('alternative value with + operator', ct => {
+  const env = { BASIC: 'expanded' }
+  const result = expandVariables('${BASIC+alternative}', env)
+  ct.same(result, 'alternative')
+  ct.end()
+})
+
+t.test('alternative value not used when variable undefined', ct => {
+  const env = { UNDEFINED: undefined }
+  const result = expandVariables('${UNDEFINED:+alternative}', env)
+  ct.same(result, '')
+  ct.end()
+})
+
+t.test('multiple expansions in same string', ct => {
+  const env = { FIRST: 'one', SECOND: 'two' }
+  const result = expandVariables('$FIRST and $SECOND', env)
+  ct.same(result, 'one and two')
+  ct.end()
+})
+
+t.test('nested default values', ct => {
+  const env = { UNDEFINED: undefined, UNDEFINED2: undefined }
+  const result = expandVariables('${UNDEFINED:-${UNDEFINED2:-nested}}', env)
+  ct.same(result, 'nested')
+  ct.end()
+})
+
+t.test('self-referential expansion stops', ct => {
+  const env = { SELF: '$SELF' }
+  const result = expandVariables('$SELF', env)
+  ct.same(result, '$SELF')
+  ct.end()
+})
+
+t.test('escaped dollar signs are not expanded', ct => {
+  const env = { BASIC: 'expanded' }
+  const result = expandVariables('\\$BASIC', env)
+  ct.same(result, '\\$BASIC')
+  ct.end()
+})
+
+t.test('literals check prevents cascading expansion', ct => {
+  // Test case: expanding a string that contains a variable whose literal value has expansion patterns
+  const env = { VAR1: 'value1', VAR2: '$VAR1' }
+  const literals = { VAR2: '$VAR1' } // VAR2 is a literal containing expansion patterns
+  // When expanding '$VAR2', it should expand to '$VAR1' and stop (not expand further to 'value1')
+  const result = expandVariables('$VAR2', env, literals)
+  ct.same(result, '$VAR1')
+  ct.end()
+})
+
+t.test('literals check allows normal expansion when literal has no patterns', ct => {
+  const env = { NORMAL_VAR: 'should expand' }
+  const literals = { NORMAL_VAR: 'no expansion patterns here' }
+  const result = expandVariables('$NORMAL_VAR', env, literals)
+  ct.same(result, 'should expand')
+  ct.end()
+})
+
+t.test('literals check prevents cascading with braced expansion', ct => {
+  const env = { VAR1: 'value1', VAR2: '${VAR1}' }
+  const literals = { VAR2: '${VAR1}' }
+  const result = expandVariables('$VAR2', env, literals)
+  ct.same(result, '${VAR1}')
+  ct.end()
+})
+
+t.test('empty literals object works', ct => {
+  const env = { BASIC: 'expanded' }
+  const result = expandVariables('$BASIC', env, {})
+  ct.same(result, 'expanded')
+  ct.end()
+})
+
+t.test('complex nested expansion with defaults', ct => {
+  const env = {
+    UNDEFINED1: undefined,
+    UNDEFINED2: undefined,
+    BASIC: 'basic_value'
+  }
+  const result = expandVariables('${UNDEFINED1:-prefix-${UNDEFINED2:-${BASIC}}-suffix}', env)
+  ct.same(result, 'prefix-basic_value-suffix')
+  ct.end()
+})
+
+t.test('expansion with special characters in default', ct => {
+  const env = { UNDEFINED: undefined }
+  const result = expandVariables('${UNDEFINED:-/path/with:colons}', env)
+  ct.same(result, '/path/with:colons')
+  ct.end()
+})


### PR DESCRIPTION
Adds cross-platform support for shell expansion using `$VAR` and `${VAR}` by expanding variables before commands are executed.  This uses the same variable expansion logic that parse.js uses.

Implements #605.