### PR TITLE
feat: add GPG and YubiKey encryption support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+dotenvx is a secure, cross-platform dotenv solution with encryption support. It provides both a CLI tool and a programmatic library for managing environment variables with features like multi-environment support and ECIES encryption (secp256k1).
+
+## Commands
+
+```bash
+# Linting (StandardJS - no config needed)
+npm run standard              # Check linting
+npm run standard:fix          # Auto-fix issues
+
+# Testing
+npm test                      # Run TAP unit tests
+npm run test-coverage         # Run tests with coverage
+npm run testshell             # Run shell/integration tests (bash/shellspec)
+npm run prerelease            # Run all tests (npm test && npm run testshell)
+
+# Local development
+./src/cli/dotenvx.js run -- echo $HELLO     # Test CLI directly
+node -e "require('./src/lib/main.js').config()"  # Test library
+```
+
+## Architecture
+
+```
+/src
+├── /cli                 # CLI interface (commander.js)
+│   ├── dotenvx.js      # Main CLI entry point (bin)
+│   ├── /actions        # CLI action implementations (run, get, set, encrypt, decrypt, etc.)
+│   └── /commands       # Complex commands (ext.js routes extension commands)
+├── /lib                # Library/programmatic interface
+│   ├── main.js         # Main export: config(), parse(), get(), set(), ls()
+│   ├── main.d.ts       # TypeScript definitions
+│   ├── /services       # Business logic classes (each has .run() method)
+│   └── /helpers        # 59+ utility functions (parse, encrypt, decrypt, buildEnvs, etc.)
+└── /shared             # Logger and colors utilities
+
+/tests                  # Mirror of src structure
+├── /lib, /cli          # TAP unit tests
+├── /monorepo           # Integration test fixtures
+└── /spec               # Shell-based tests (shellspec)
+```
+
+### Control Flow
+
+```
+CLI Commands → CLI Actions → Services → Helpers
+                                ↓
+                          Shared Utilities
+```
+
+### Key Entry Points
+
+- **CLI**: `/src/cli/dotenvx.js` - commander.js based CLI
+- **Library**: `/src/lib/main.js` - exports `config()`, `parse()`, `get()`, `set()`, `ls()`
+- **Auto-config**: `require('@dotenvx/dotenvx/config')` - calls config() on import
+
+## Key Patterns
+
+### Encryption
+- ECIES with secp256k1 (Bitcoin-grade crypto)
+- Encrypted values prefixed with `"encrypted:"`
+- Public key: `DOTENV_PUBLIC_KEY` in `.env` file
+- Private key: `DOTENV_PRIVATE_KEY` in `.env.keys` (gitignored)
+
+### Error Handling
+- Centralized in `/lib/helpers/errors.js`
+- Named error codes: `MISSING_ENV_FILE`, `MISSING_KEY`, etc.
+- `strict` mode throws immediately; tolerant mode logs and continues
+
+### Environment Processing Pipeline
+1. Discover .env files → 2. Read → 3. Parse → 4. Expand variables → 5. Decrypt → 6. Write to process.env
+
+### Convention Support
+- `nextjs`: Next.js environment loading order
+- `flow`: dotenv-flow convention
+
+## Testing
+
+- **TAP tests**: `npm test` - unit tests with tap framework
+- **Shell tests**: `npm run testshell` - integration tests via shellspec
+- **Mocking**: proxyquire and sinon for dependency injection
+- **Fixtures**: `/tests/monorepo/apps/` for multi-app test scenarios

--- a/claude-docs/01-add-yubikey-gpg-support/IMPLEMENTATION-PLAN.md
+++ b/claude-docs/01-add-yubikey-gpg-support/IMPLEMENTATION-PLAN.md
@@ -1,0 +1,861 @@
+# YubiKey + GPG Support Implementation Plan for dotenvx
+
+## Executive Summary
+
+This plan extends dotenvx to support GPG-based encryption/decryption of environment variables, enabling YubiKey hardware security module integration. The implementation adds a `--gpg` flag to existing commands while maintaining full backward compatibility with ECIES encryption.
+
+---
+
+## Design Decisions (Confirmed)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Trigger Method | `--gpg` flag on existing commands | Cleanest upgrade path, non-breaking |
+| Config Persistence | `DOTENVX_CRYPTO=gpg` env var | No new file system, simple |
+| Encryption Scope | Individual values | Consistent with ECIES approach |
+| Key Reference | Both key ID/fingerprint and email | Maximum flexibility |
+| GPG Backend | gpg CLI (spawn) | YubiKey works out of box |
+| Encrypted Prefix | `gpg:encrypted:` | Clear distinction from ECIES |
+
+---
+
+## Architecture Overview
+
+### Current ECIES Flow
+```
+encrypt: value → eciesjs.encrypt(publicKey, value) → "encrypted:BASE64"
+decrypt: "encrypted:BASE64" → eciesjs.decrypt(privateKey, ciphertext) → value
+```
+
+### New GPG Flow
+```
+encrypt: value → gpg --encrypt --recipient KEY → "gpg:encrypted:BASE64"
+decrypt: "gpg:encrypted:BASE64" → gpg --decrypt → value (YubiKey prompts for PIN)
+```
+
+### Unified Architecture
+```
+                     ┌─────────────────────────────────────────┐
+                     │           CLI Layer                     │
+                     │  encrypt/decrypt/set/run commands       │
+                     │         + --gpg flag                    │
+                     └─────────────────┬───────────────────────┘
+                                       │
+                     ┌─────────────────▼───────────────────────┐
+                     │         Service Layer                   │
+                     │  Encrypt/Decrypt/Sets services          │
+                     │  (crypto provider selection)            │
+                     └─────────────────┬───────────────────────┘
+                                       │
+              ┌────────────────────────┼────────────────────────┐
+              │                        │                        │
+    ┌─────────▼─────────┐    ┌────────▼────────┐    ┌─────────▼─────────┐
+    │   ECIES Helpers   │    │   GPG Helpers   │    │  Crypto Strategy  │
+    │ encryptValue.js   │    │ gpgEncrypt.js   │    │  getCryptoProvider│
+    │ decryptKeyValue.js│    │ gpgDecrypt.js   │    │                   │
+    └───────────────────┘    └─────────────────┘    └───────────────────┘
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core GPG Helpers (Foundation)
+
+#### 1.1 Create `src/lib/helpers/gpgAvailable.js`
+Check if gpg is installed and accessible.
+
+```javascript
+// Checks if gpg CLI is available
+// Returns: { available: boolean, version: string|null, error: string|null }
+const { execSync } = require('child_process')
+
+function gpgAvailable () {
+  try {
+    const version = execSync('gpg --version', { encoding: 'utf8', timeout: 5000 })
+    const match = version.match(/gpg \(GnuPG\) (\d+\.\d+\.\d+)/)
+    return {
+      available: true,
+      version: match ? match[1] : 'unknown',
+      error: null
+    }
+  } catch (e) {
+    return {
+      available: false,
+      version: null,
+      error: 'gpg not found. Install GnuPG: https://gnupg.org/download/'
+    }
+  }
+}
+
+module.exports = gpgAvailable
+```
+
+#### 1.2 Create `src/lib/helpers/gpgEncryptValue.js`
+Encrypt a single value using GPG.
+
+```javascript
+// Encrypts value using GPG with specified recipient
+// recipient: GPG key ID, fingerprint, or email
+// Returns: "gpg:encrypted:BASE64"
+const { execSync } = require('child_process')
+
+const GPG_PREFIX = 'gpg:encrypted:'
+
+function gpgEncryptValue (value, recipient) {
+  // Validate recipient
+  if (!recipient) {
+    const error = new Error('GPG recipient (key ID or email) is required')
+    error.code = 'MISSING_GPG_RECIPIENT'
+    error.help = 'Set DOTENV_GPG_KEY or use --gpg-key flag'
+    throw error
+  }
+
+  try {
+    // --armor: ASCII output
+    // --trust-model always: skip trust db check (useful for CI)
+    // --batch: non-interactive
+    // --yes: overwrite without prompt
+    const ciphertext = execSync(
+      `gpg --encrypt --armor --recipient "${recipient}" --trust-model always --batch --yes`,
+      {
+        input: value,
+        encoding: 'utf8',
+        timeout: 30000, // 30s timeout for YubiKey interaction
+        stdio: ['pipe', 'pipe', 'pipe']
+      }
+    )
+
+    // Extract base64 from ASCII armor
+    const base64 = extractBase64FromArmor(ciphertext)
+    return `${GPG_PREFIX}${base64}`
+  } catch (e) {
+    const error = new Error(`GPG encryption failed: ${e.message}`)
+    error.code = 'GPG_ENCRYPTION_FAILED'
+    error.help = `Verify GPG key exists: gpg --list-keys ${recipient}`
+    throw error
+  }
+}
+
+function extractBase64FromArmor (armoredText) {
+  // Remove header, footer, and blank lines
+  const lines = armoredText.split('\n')
+  const dataLines = lines.filter(line =>
+    !line.startsWith('-----') &&
+    !line.startsWith('Version:') &&
+    !line.startsWith('Comment:') &&
+    line.trim() !== ''
+  )
+  return dataLines.join('')
+}
+
+module.exports = gpgEncryptValue
+module.exports.GPG_PREFIX = GPG_PREFIX
+```
+
+#### 1.3 Create `src/lib/helpers/gpgDecryptValue.js`
+Decrypt a GPG-encrypted value (will prompt for YubiKey PIN if configured).
+
+```javascript
+// Decrypts GPG-encrypted value
+// For YubiKey: will trigger PIN prompt via gpg-agent
+// Returns: plaintext value
+const { execSync, spawnSync } = require('child_process')
+
+const GPG_PREFIX = 'gpg:encrypted:'
+
+function gpgDecryptValue (key, value) {
+  if (!value.startsWith(GPG_PREFIX)) {
+    return value
+  }
+
+  const base64 = value.substring(GPG_PREFIX.length)
+  const armoredCiphertext = wrapInArmor(base64)
+
+  try {
+    // gpg-agent handles PIN prompts for YubiKey
+    // --batch allows non-interactive if key is unlocked
+    // Without --batch, allows PIN prompts
+    const result = spawnSync('gpg', ['--decrypt', '--quiet'], {
+      input: armoredCiphertext,
+      encoding: 'utf8',
+      timeout: 60000, // 60s timeout for YubiKey PIN entry
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+
+    if (result.status !== 0) {
+      throw new Error(result.stderr || 'Decryption failed')
+    }
+
+    return result.stdout
+  } catch (e) {
+    const error = new Error(`GPG decryption failed for key '${key}': ${e.message}`)
+    error.code = 'GPG_DECRYPTION_FAILED'
+    error.help = [
+      'Possible causes:',
+      '  1. YubiKey not inserted',
+      '  2. Wrong PIN entered',
+      '  3. GPG key not available',
+      'Debug: gpg --decrypt --verbose'
+    ].join('\n')
+    throw error
+  }
+}
+
+function wrapInArmor (base64) {
+  // Reconstruct PGP message armor
+  const lines = base64.match(/.{1,64}/g) || [base64]
+  return [
+    '-----BEGIN PGP MESSAGE-----',
+    '',
+    ...lines,
+    '-----END PGP MESSAGE-----'
+  ].join('\n')
+}
+
+module.exports = gpgDecryptValue
+module.exports.GPG_PREFIX = GPG_PREFIX
+```
+
+#### 1.4 Create `src/lib/helpers/isGpgEncrypted.js`
+Check if a value is GPG-encrypted.
+
+```javascript
+const GPG_PREFIX = 'gpg:encrypted:'
+
+function isGpgEncrypted (value) {
+  if (typeof value !== 'string') {
+    return false
+  }
+  return value.startsWith(GPG_PREFIX)
+}
+
+module.exports = isGpgEncrypted
+```
+
+#### 1.5 Create `src/lib/helpers/getCryptoProvider.js`
+Determine which crypto provider to use based on options and environment.
+
+```javascript
+// Determines crypto provider: 'ecies' (default) or 'gpg'
+// Priority: 1. --gpg flag, 2. DOTENVX_CRYPTO env, 3. default 'ecies'
+
+function getCryptoProvider (options = {}) {
+  // Explicit --gpg flag takes highest priority
+  if (options.gpg === true) {
+    return 'gpg'
+  }
+
+  // Check environment variable
+  const envCrypto = process.env.DOTENVX_CRYPTO
+  if (envCrypto === 'gpg') {
+    return 'gpg'
+  }
+
+  // Default to ECIES
+  return 'ecies'
+}
+
+module.exports = getCryptoProvider
+```
+
+#### 1.6 Create `src/lib/helpers/getGpgRecipient.js`
+Get GPG recipient from options or environment.
+
+```javascript
+// Gets GPG recipient (key ID, fingerprint, or email)
+// Priority: 1. --gpg-key flag, 2. DOTENV_GPG_KEY env
+
+function getGpgRecipient (options = {}, envFilepath = null) {
+  // Check --gpg-key flag
+  if (options.gpgKey) {
+    return options.gpgKey
+  }
+
+  // Check environment variables
+  // Support environment-specific keys: DOTENV_GPG_KEY_PRODUCTION, etc.
+  if (envFilepath) {
+    const envSuffix = getEnvSuffix(envFilepath)
+    if (envSuffix) {
+      const envSpecificKey = process.env[`DOTENV_GPG_KEY_${envSuffix.toUpperCase()}`]
+      if (envSpecificKey) {
+        return envSpecificKey
+      }
+    }
+  }
+
+  // Fallback to generic key
+  return process.env.DOTENV_GPG_KEY || null
+}
+
+function getEnvSuffix (envFilepath) {
+  // Extract environment from filepath like .env.production → PRODUCTION
+  const match = envFilepath.match(/\.env\.(.+)$/)
+  return match ? match[1] : null
+}
+
+module.exports = getGpgRecipient
+```
+
+---
+
+### Phase 2: Update Existing Helpers
+
+#### 2.1 Update `src/lib/helpers/isEncrypted.js`
+Add GPG encryption detection.
+
+```javascript
+// Current: checks for 'encrypted:' prefix (ECIES)
+// Updated: also check for 'gpg:encrypted:' prefix
+
+const ECIES_PREFIX = 'encrypted:'
+const GPG_PREFIX = 'gpg:encrypted:'
+
+function isEncrypted (value) {
+  if (typeof value !== 'string') {
+    return false
+  }
+  return value.startsWith(ECIES_PREFIX) || value.startsWith(GPG_PREFIX)
+}
+
+module.exports = isEncrypted
+```
+
+#### 2.2 Update `src/lib/helpers/decryptKeyValue.js`
+Add GPG decryption support alongside ECIES.
+
+```javascript
+// Add at top
+const gpgDecryptValue = require('./gpgDecryptValue')
+const isGpgEncrypted = require('./isGpgEncrypted')
+
+// In function body, add GPG branch:
+function decryptKeyValue (key, value, privateKeyName, privateKey) {
+  // Handle GPG-encrypted values
+  if (isGpgEncrypted(value)) {
+    return gpgDecryptValue(key, value)
+  }
+
+  // Existing ECIES logic...
+}
+```
+
+---
+
+### Phase 3: Update Services
+
+#### 3.1 Update `src/lib/services/encrypt.js`
+Add GPG encryption mode.
+
+**Constructor changes:**
+```javascript
+constructor (envs = [], key = [], excludeKey = [], envKeysFilepath = null, options = {}) {
+  // ... existing ...
+  this.cryptoProvider = getCryptoProvider(options)
+  this.gpgRecipient = getGpgRecipient(options)
+}
+```
+
+**_encryptEnvFile changes:**
+```javascript
+// In the encryption loop, branch based on crypto provider:
+if (this.cryptoProvider === 'gpg') {
+  if (!this.gpgRecipient) {
+    throw new Error('GPG recipient required. Use --gpg-key or set DOTENV_GPG_KEY')
+  }
+  const encryptedValue = gpgEncryptValue(value, this.gpgRecipient)
+  // ... rest same ...
+} else {
+  // Existing ECIES logic
+  const encryptedValue = encryptValue(value, publicKey)
+  // ...
+}
+```
+
+**Key differences for GPG mode:**
+- No keypair generation (uses existing GPG keys)
+- No .env.keys file needed (GPG keyring is separate)
+- Store `DOTENV_GPG_KEY` in .env file header instead of public key
+
+#### 3.2 Update `src/lib/services/decrypt.js`
+Add GPG decryption mode (mostly handled by updated decryptKeyValue helper).
+
+**Changes:**
+- The `decryptKeyValue` helper now handles GPG automatically
+- For GPG values, privateKey parameter is ignored (gpg-agent handles it)
+- Add logging for YubiKey operations
+
+#### 3.3 Update `src/lib/services/sets.js`
+Add GPG support to the set command.
+
+**Constructor changes:**
+```javascript
+constructor (key, value, envs = [], encrypt = true, envKeysFilepath = null, options = {}) {
+  // ... existing ...
+  this.cryptoProvider = getCryptoProvider(options)
+  this.gpgRecipient = getGpgRecipient(options)
+}
+```
+
+**_setEnvFile changes:**
+- Branch encryption logic based on `this.cryptoProvider`
+- For GPG: use `gpgEncryptValue` instead of ECIES
+- Skip keypair generation for GPG mode
+
+---
+
+### Phase 4: Update CLI Commands
+
+#### 4.1 Update `src/cli/dotenvx.js` - Add Global GPG Options
+
+```javascript
+// Add to encrypt command
+program.command('encrypt')
+  // ... existing options ...
+  .option('--gpg', 'use GPG encryption instead of ECIES')
+  .option('--gpg-key <recipient>', 'GPG key ID, fingerprint, or email for encryption')
+  .action(function (...args) {
+    this.envs = envs
+    this.gpgOptions = { gpg: this.opts().gpg, gpgKey: this.opts().gpgKey }
+    encryptAction.apply(this, args)
+  })
+
+// Add to decrypt command
+program.command('decrypt')
+  // ... existing options ...
+  .option('--gpg', 'expect GPG-encrypted values (auto-detected if not specified)')
+  .action(function (...args) {
+    this.envs = envs
+    this.gpgOptions = { gpg: this.opts().gpg }
+    decryptAction.apply(this, args)
+  })
+
+// Add to set command
+program.command('set')
+  // ... existing options ...
+  .option('--gpg', 'use GPG encryption instead of ECIES')
+  .option('--gpg-key <recipient>', 'GPG key ID, fingerprint, or email for encryption')
+  .action(function (...args) {
+    this.envs = envs
+    this.gpgOptions = { gpg: this.opts().gpg, gpgKey: this.opts().gpgKey }
+    setAction.apply(this, args)
+  })
+
+// Add to run command
+program.command('run')
+  // ... existing options ...
+  .option('--gpg', 'expect GPG-encrypted values (for YubiKey decryption)')
+```
+
+#### 4.2 Update `src/cli/actions/encrypt.js`
+
+```javascript
+function encrypt () {
+  const options = this.opts()
+  const gpgOptions = this.gpgOptions || {}
+
+  // Check GPG availability if --gpg flag used
+  if (gpgOptions.gpg) {
+    const gpg = gpgAvailable()
+    if (!gpg.available) {
+      logger.error(gpg.error)
+      process.exit(1)
+    }
+    logger.verbose(`Using GPG ${gpg.version}`)
+  }
+
+  // Pass gpgOptions to service
+  const service = new Encrypt(envs, options.key, options.excludeKey, options.envKeysFile, gpgOptions)
+  // ... rest of logic ...
+}
+```
+
+#### 4.3 Update `src/cli/actions/decrypt.js`
+
+```javascript
+function decrypt () {
+  const options = this.opts()
+  const gpgOptions = this.gpgOptions || {}
+
+  // For GPG decryption, warn about YubiKey
+  if (gpgOptions.gpg) {
+    logger.verbose('GPG mode: YubiKey PIN may be required')
+  }
+
+  // ... rest of logic (decryptKeyValue handles GPG automatically) ...
+}
+```
+
+#### 4.4 Update `src/cli/actions/set.js`
+
+```javascript
+function set (key, value) {
+  const options = this.opts()
+  const gpgOptions = this.gpgOptions || {}
+
+  // Check GPG availability if using GPG encryption
+  if (gpgOptions.gpg && !options.plain) {
+    const gpg = gpgAvailable()
+    if (!gpg.available) {
+      logger.error(gpg.error)
+      process.exit(1)
+    }
+  }
+
+  // Pass gpgOptions to service
+  const service = new Sets(key, value, envs, encrypt, options.envKeysFile, gpgOptions)
+  // ... rest of logic ...
+}
+```
+
+#### 4.5 Update CLI Examples (`src/cli/examples.js`)
+
+Add GPG examples:
+
+```javascript
+const gpgExamples = `
+Examples:
+  $ dotenvx encrypt --gpg --gpg-key user@example.com
+  $ dotenvx encrypt --gpg --gpg-key 0x1234ABCD
+  $ dotenvx set SECRET value --gpg --gpg-key user@example.com
+  $ DOTENV_GPG_KEY=user@example.com dotenvx encrypt --gpg
+  $ DOTENVX_CRYPTO=gpg dotenvx encrypt
+`
+```
+
+---
+
+### Phase 5: Update TypeScript Definitions
+
+#### 5.1 Update `src/lib/main.d.ts`
+
+```typescript
+// Add to DotenvConfigOptions
+export interface DotenvConfigOptions {
+  // ... existing ...
+
+  /** Use GPG encryption instead of ECIES */
+  gpg?: boolean
+
+  /** GPG key ID, fingerprint, or email for encryption */
+  gpgKey?: string
+}
+
+// Add new exports
+export function gpgAvailable(): { available: boolean; version: string | null; error: string | null }
+```
+
+---
+
+### Phase 6: Error Handling
+
+#### 6.1 Update `src/lib/helpers/errors.js`
+
+Add GPG-specific error codes:
+
+```javascript
+// Add new error methods
+missingGpgKey () {
+  const error = new Error(`[MISSING_GPG_KEY] GPG key not specified`)
+  error.code = 'MISSING_GPG_KEY'
+  error.help = `[MISSING_GPG_KEY] Set DOTENV_GPG_KEY environment variable or use --gpg-key flag`
+  return error
+}
+
+gpgNotAvailable () {
+  const error = new Error(`[GPG_NOT_AVAILABLE] gpg command not found`)
+  error.code = 'GPG_NOT_AVAILABLE'
+  error.help = `[GPG_NOT_AVAILABLE] Install GnuPG: https://gnupg.org/download/`
+  return error
+}
+
+gpgEncryptionFailed (details) {
+  const error = new Error(`[GPG_ENCRYPTION_FAILED] ${details}`)
+  error.code = 'GPG_ENCRYPTION_FAILED'
+  error.help = `[GPG_ENCRYPTION_FAILED] Check GPG key availability: gpg --list-keys`
+  return error
+}
+
+gpgDecryptionFailed (key, details) {
+  const error = new Error(`[GPG_DECRYPTION_FAILED] Unable to decrypt '${key}': ${details}`)
+  error.code = 'GPG_DECRYPTION_FAILED'
+  error.help = `[GPG_DECRYPTION_FAILED] Ensure YubiKey is inserted and correct PIN is used`
+  return error
+}
+
+yubiKeyNotPresent () {
+  const error = new Error(`[YUBIKEY_NOT_PRESENT] YubiKey required for decryption`)
+  error.code = 'YUBIKEY_NOT_PRESENT'
+  error.help = `[YUBIKEY_NOT_PRESENT] Insert your YubiKey and try again`
+  return error
+}
+```
+
+---
+
+### Phase 7: Testing
+
+#### 7.1 Unit Tests for New Helpers
+
+Create test files:
+- `tests/lib/helpers/gpgAvailable.test.js`
+- `tests/lib/helpers/gpgEncryptValue.test.js`
+- `tests/lib/helpers/gpgDecryptValue.test.js`
+- `tests/lib/helpers/isGpgEncrypted.test.js`
+- `tests/lib/helpers/getCryptoProvider.test.js`
+- `tests/lib/helpers/getGpgRecipient.test.js`
+
+**Test Strategy:**
+- Mock gpg CLI calls using proxyquire/sinon
+- Test error cases (gpg not installed, invalid key, etc.)
+- Test armor encoding/decoding
+- Test prefix detection
+
+#### 7.2 Integration Tests for Services
+
+Update existing test files:
+- `tests/lib/services/encrypt.test.js` - add GPG mode tests
+- `tests/lib/services/decrypt.test.js` - add GPG mode tests
+- `tests/lib/services/sets.test.js` - add GPG mode tests
+
+**Test Strategy:**
+- Mock gpg CLI to avoid requiring actual GPG installation in CI
+- Test crypto provider selection
+- Test that ECIES still works unchanged
+
+#### 7.3 CLI Tests
+
+Update:
+- `tests/cli/actions/encrypt.test.js`
+- `tests/cli/actions/decrypt.test.js`
+- `tests/cli/actions/set.test.js`
+
+**Test Strategy:**
+- Test --gpg flag parsing
+- Test --gpg-key flag parsing
+- Test DOTENVX_CRYPTO env var
+
+#### 7.4 Shell Integration Tests
+
+Add to `spec/`:
+- `spec/gpg_encrypt_spec.sh` - if gpg available
+- `spec/gpg_decrypt_spec.sh`
+
+**Note:** These tests should be skipped in CI unless GPG test keys are set up.
+
+---
+
+### Phase 8: Documentation
+
+#### 8.1 Update README.md
+
+Add GPG section:
+
+```markdown
+## GPG / YubiKey Encryption
+
+dotenvx supports GPG encryption for hardware security module integration.
+
+### Prerequisites
+- GnuPG installed (`gpg --version`)
+- GPG key pair generated
+- (Optional) YubiKey configured with GPG
+
+### Usage
+
+```bash
+# Encrypt with GPG
+dotenvx encrypt --gpg --gpg-key user@example.com
+
+# Set with GPG encryption
+dotenvx set API_KEY secret123 --gpg --gpg-key 0x1234ABCD
+
+# Run with GPG-encrypted env (YubiKey PIN will be prompted)
+dotenvx run --gpg -- node app.js
+
+# Set default crypto provider
+export DOTENVX_CRYPTO=gpg
+export DOTENV_GPG_KEY=user@example.com
+dotenvx encrypt  # now uses GPG by default
+```
+
+### YubiKey Integration
+
+When using a YubiKey, the GPG agent will prompt for your PIN:
+- First use: Enter PIN
+- Subsequent uses: Cached for session (configurable)
+
+Configure PIN caching in `~/.gnupg/gpg-agent.conf`:
+```
+default-cache-ttl 600
+max-cache-ttl 7200
+```
+```
+
+#### 8.2 Add GPG-specific examples to CLI help
+
+Update `src/cli/examples.js` with GPG examples for each relevant command.
+
+---
+
+## File Change Summary
+
+### New Files (8)
+| File | Purpose |
+|------|---------|
+| `src/lib/helpers/gpgAvailable.js` | Check gpg CLI availability |
+| `src/lib/helpers/gpgEncryptValue.js` | GPG encryption |
+| `src/lib/helpers/gpgDecryptValue.js` | GPG decryption |
+| `src/lib/helpers/isGpgEncrypted.js` | Check GPG prefix |
+| `src/lib/helpers/getCryptoProvider.js` | Select crypto provider |
+| `src/lib/helpers/getGpgRecipient.js` | Get GPG recipient |
+| `tests/lib/helpers/gpg*.test.js` | Unit tests (6 files) |
+| `spec/gpg_*.sh` | Shell integration tests |
+
+### Modified Files (12)
+| File | Changes |
+|------|---------|
+| `src/lib/helpers/isEncrypted.js` | Add GPG prefix check |
+| `src/lib/helpers/decryptKeyValue.js` | Add GPG branch |
+| `src/lib/helpers/errors.js` | Add GPG error codes |
+| `src/lib/services/encrypt.js` | Add GPG mode |
+| `src/lib/services/decrypt.js` | Support GPG values |
+| `src/lib/services/sets.js` | Add GPG mode |
+| `src/cli/dotenvx.js` | Add --gpg, --gpg-key flags |
+| `src/cli/actions/encrypt.js` | Pass gpgOptions |
+| `src/cli/actions/decrypt.js` | Pass gpgOptions |
+| `src/cli/actions/set.js` | Pass gpgOptions |
+| `src/cli/examples.js` | Add GPG examples |
+| `src/lib/main.d.ts` | Add GPG types |
+
+---
+
+## Potential Challenges & Mitigations
+
+### Challenge 1: GPG Agent / Pinentry
+**Problem:** GPG decryption requires gpg-agent for PIN prompts, which may not work in all terminal environments.
+
+**Mitigation:**
+- Document gpg-agent configuration
+- Suggest `GPG_TTY=$(tty)` for terminal issues
+- Support `--batch` mode for pre-unlocked keys
+- Add verbose logging for debugging
+
+### Challenge 2: YubiKey Not Present
+**Problem:** Runtime failures if YubiKey is removed mid-session.
+
+**Mitigation:**
+- Clear error messages directing user to insert YubiKey
+- Graceful timeout handling (60s default)
+- Option to skip GPG values with `--ignore=GPG_DECRYPTION_FAILED`
+
+### Challenge 3: Mixed Encryption (ECIES + GPG in same file)
+**Problem:** A .env file could have both ECIES and GPG encrypted values.
+
+**Mitigation:**
+- Both prefixes are distinct (`encrypted:` vs `gpg:encrypted:`)
+- `decryptKeyValue` detects prefix and routes accordingly
+- Document that mixing is supported
+
+### Challenge 4: CI/CD Environments
+**Problem:** GPG/YubiKey doesn't work in CI without setup.
+
+**Mitigation:**
+- Document that ECIES is recommended for CI
+- Support pre-exported private keys via env vars
+- Consider supporting `--gpg-passphrase` for non-interactive CI (with strong warnings)
+
+### Challenge 5: Cross-Platform GPG Paths
+**Problem:** GPG installation varies by OS (gpg vs gpg2, different paths).
+
+**Mitigation:**
+- Use `which gpg` to find binary
+- Fall back to `gpg2` if `gpg` not found
+- Support `DOTENVX_GPG_BIN` override env var
+
+### Challenge 6: Large Values
+**Problem:** GPG has size limits and is slower than ECIES for large payloads.
+
+**Mitigation:**
+- Document that GPG is best for small secrets
+- Add warning for values > 100KB
+- ECIES remains default for performance-critical use
+
+---
+
+## Implementation Order
+
+Recommended order for incremental development:
+
+1. **Phase 1** (Core Helpers) - Can be unit tested independently
+2. **Phase 6** (Error Handling) - Foundation for good error messages
+3. **Phase 2** (Update isEncrypted, decryptKeyValue) - Enable reading GPG values
+4. **Phase 4.1-4.3** (CLI flags) - Wire up the interface
+5. **Phase 3** (Services) - Connect helpers to services
+6. **Phase 7** (Testing) - Validate implementation
+7. **Phase 5** (TypeScript) - Add type definitions
+8. **Phase 8** (Documentation) - Document features
+
+---
+
+## Usage Examples (Post-Implementation)
+
+### Basic GPG Encryption
+```bash
+# Generate GPG key (one-time)
+gpg --gen-key
+
+# Encrypt .env file with GPG
+dotenvx encrypt --gpg --gpg-key your@email.com
+
+# Result: values now have gpg:encrypted: prefix
+# DOTENV_GPG_KEY added to .env header
+```
+
+### YubiKey Workflow
+```bash
+# Developer with YubiKey
+export DOTENV_GPG_KEY=your@email.com
+
+# Encrypt secrets
+dotenvx set DATABASE_URL "postgres://..." --gpg
+
+# Run application (YubiKey PIN prompted once per session)
+dotenvx run -- node app.js
+```
+
+### Persistent GPG Default
+```bash
+# Set default in shell profile
+export DOTENVX_CRYPTO=gpg
+export DOTENV_GPG_KEY=your@email.com
+
+# Now all dotenvx commands use GPG by default
+dotenvx encrypt        # uses GPG
+dotenvx set KEY value  # encrypts with GPG
+```
+
+### Mixed Team (Some with YubiKey, Some Without)
+```bash
+# Team member with YubiKey encrypts
+dotenvx encrypt --gpg --gpg-key team-secrets@company.com
+
+# Team member without YubiKey can still read if they have the GPG private key
+# (exported from YubiKey and imported to their gpg keyring)
+dotenvx run -- node app.js
+```
+
+---
+
+## Success Criteria
+
+- [ ] `dotenvx encrypt --gpg --gpg-key KEY` encrypts values with `gpg:encrypted:` prefix
+- [ ] `dotenvx decrypt` auto-detects and decrypts GPG values
+- [ ] YubiKey prompts for PIN during decryption
+- [ ] ECIES continues to work unchanged (backward compatible)
+- [ ] Mixed ECIES + GPG values in same file work
+- [ ] Clear error messages for missing GPG, missing key, YubiKey issues
+- [ ] All existing tests pass
+- [ ] New GPG tests pass (with mocked gpg)
+- [ ] TypeScript definitions updated
+- [ ] README documents GPG usage

--- a/claude-docs/01-add-yubikey-gpg-support/IMPLEMENTATION-PROGRESS.md
+++ b/claude-docs/01-add-yubikey-gpg-support/IMPLEMENTATION-PROGRESS.md
@@ -1,0 +1,305 @@
+# YubiKey + GPG Support Implementation Progress
+
+## Status: COMPLETE
+
+All tasks have been implemented, all 2435 tests pass, and StandardJS linting passes.
+
+---
+
+## Implementation Summary
+
+### Design Decisions Made
+
+Based on user input, the following design choices were made:
+
+| Decision | Choice |
+|----------|--------|
+| Trigger method | `--gpg` flag on existing commands |
+| Encryption scope | Individual values (like ECIES approach) |
+| Key reference | Both key ID/fingerprint and email supported |
+| GPG backend | GPG CLI (spawn) for YubiKey compatibility |
+| Config storage | `DOTENVX_CRYPTO=gpg` environment variable |
+| Encrypted prefix | `gpg:encrypted:` |
+
+---
+
+## Files Created
+
+### New Helper Files (6 files)
+
+1. **`src/lib/helpers/gpgAvailable.js`**
+   - Checks if GPG CLI (`gpg` or `gpg2`) is available
+   - Returns version info and binary path
+   - Used to validate GPG installation before encryption
+
+2. **`src/lib/helpers/gpgEncryptValue.js`**
+   - Encrypts values using GPG CLI
+   - Uses ASCII armor format, extracts base64 content
+   - Returns `gpg:encrypted:<base64>` format
+   - Spawns: `gpg --encrypt --armor --recipient X --trust-model always --batch --yes`
+
+3. **`src/lib/helpers/gpgDecryptValue.js`**
+   - Decrypts GPG-encrypted values
+   - Reconstructs ASCII armor from base64 for GPG CLI
+   - 60-second timeout for YubiKey PIN entry
+   - Handles `YUBIKEY_NOT_PRESENT` and `GPG_BAD_PIN` errors
+
+4. **`src/lib/helpers/isGpgEncrypted.js`**
+   - Simple check for `gpg:encrypted:` prefix
+   - Used to route decryption to correct handler
+
+5. **`src/lib/helpers/getCryptoProvider.js`**
+   - Determines crypto provider from options/environment
+   - Priority: `options.gpg=true` > `DOTENVX_CRYPTO=gpg` > default `ecies`
+
+6. **`src/lib/helpers/getGpgRecipient.js`**
+   - Gets GPG recipient (key ID/email) from multiple sources
+   - Priority: `options.gpgKey` > `DOTENV_GPG_KEY_<ENV>` > `DOTENV_GPG_KEY`
+
+### New Test Files (4 files)
+
+1. **`tests/lib/helpers/gpgAvailable.test.js`**
+   - Tests GPG detection with mocked child_process
+   - Tests fallback from `gpg` to `gpg2`
+   - Tests version parsing
+
+2. **`tests/lib/helpers/getCryptoProvider.test.js`**
+   - Tests default ECIES behavior
+   - Tests `--gpg` flag override
+   - Tests `DOTENVX_CRYPTO` environment variable
+
+3. **`tests/lib/helpers/getGpgRecipient.test.js`**
+   - Tests option precedence
+   - Tests environment-specific keys (e.g., `DOTENV_GPG_KEY_PRODUCTION`)
+   - Tests fallback behavior
+
+4. **`tests/lib/helpers/isGpgEncrypted.test.js`**
+   - Tests `gpg:encrypted:` prefix detection
+   - Tests non-GPG values return false
+
+---
+
+## Files Modified
+
+### CLI Layer
+
+1. **`src/cli/dotenvx.js`**
+   - Added `--gpg` flag to `encrypt`, `decrypt`, and `set` commands
+   - Added `--gpg-key <recipient>` option for specifying GPG key
+
+2. **`src/cli/actions/encrypt.js`**
+   - Added GPG availability check when `--gpg` flag is used
+   - Added GPG-specific success messages
+   - Shows GPG recipient and YubiKey PIN prompt info
+
+3. **`src/cli/actions/set.js`**
+   - Added GPG availability check when `--gpg` flag is used
+   - Added GPG-specific success messages
+   - Passes gpgOptions to Sets service
+
+### Service Layer
+
+4. **`src/lib/services/encrypt.js`**
+   - Added full GPG encryption mode with branching logic
+   - Constructor now accepts `options` parameter for GPG settings
+   - Added `_prependGpgKey()` for DOTENV_GPG_KEY header generation
+   - Added `_guessGpgKeyName()` for environment-specific GPG key names
+   - Added `_isGpgKeyVar()` to skip encrypting GPG key variables
+   - GPG mode stores `DOTENV_GPG_KEY` in .env header (no .env.keys file needed)
+
+5. **`src/lib/services/sets.js`**
+   - Added GPG encryption support mirroring encrypt.js
+   - Added same helper methods for GPG key handling
+   - Handles GPG-encrypted value comparison for change detection
+
+### Helper Layer
+
+6. **`src/lib/helpers/isEncrypted.js`**
+   - Now detects both ECIES (`encrypted:`) and GPG (`gpg:encrypted:`) prefixes
+   - Added type checking for non-string values
+
+7. **`src/lib/helpers/decryptKeyValue.js`**
+   - Added GPG detection at start of function
+   - Routes GPG-encrypted values to `gpgDecryptValue`
+   - Falls through to existing ECIES logic for non-GPG values
+
+8. **`src/lib/helpers/errors.js`**
+   - Added `missingGpgRecipient()` - when --gpg-key not provided
+   - Added `gpgNotAvailable()` - when GPG CLI not found
+   - Added `gpgEncryptionFailed()` - encryption errors
+   - Added `gpgDecryptionFailed()` - decryption errors
+   - Added `yubiKeyNotPresent()` - YubiKey not inserted
+   - Added `gpgBadPin()` - incorrect PIN entered
+
+### Type Definitions
+
+9. **`src/lib/main.d.ts`**
+   - Added `gpg` and `gpgKey` to `SetOptions` interface
+   - Added `cryptoProvider` and `gpgRecipient` to `SetProcessedEnv` interface
+   - Added `GpgAvailableOutput` interface
+   - Added `gpgAvailable()` function export
+
+### Exports
+
+10. **`src/lib/main.js`**
+    - Exported `gpgAvailable` function for programmatic access
+    - Updated `set()` function to pass gpgOptions to Sets service
+
+### Tests
+
+11. **`tests/lib/helpers/isEncrypted.test.js`**
+    - Added tests for GPG encrypted values
+    - Added tests for undefined/number inputs
+
+---
+
+## Git Diff Summary
+
+```
+ src/cli/actions/encrypt.js            |  33 +++-
+ src/cli/actions/set.js                |  31 +++-
+ src/cli/dotenvx.js                    |   5 +
+ src/lib/helpers/decryptKeyValue.js    |   7 +
+ src/lib/helpers/errors.js             |  67 ++++++++
+ src/lib/helpers/isEncrypted.js        |  13 +-
+ src/lib/main.d.ts                     |  36 +++++
+ src/lib/main.js                       |  11 +-
+ src/lib/services/encrypt.js           | 280 ++++++++++++++++++++++------------
+ src/lib/services/sets.js              | 206 ++++++++++++++++---------
+ tests/lib/helpers/isEncrypted.test.js |  24 +++
+ 11 files changed, 540 insertions(+), 173 deletions(-)
+```
+
+Plus 10 new files (6 helpers + 4 tests).
+
+---
+
+## Usage Examples
+
+### Encrypt with GPG
+
+```bash
+# Encrypt all values in .env with GPG
+dotenvx encrypt --gpg --gpg-key user@example.com
+
+# Encrypt specific file
+dotenvx encrypt -f .env.production --gpg --gpg-key user@example.com
+
+# Encrypt specific keys only
+dotenvx encrypt -k "API_KEY" -k "SECRET" --gpg --gpg-key user@example.com
+```
+
+### Set Value with GPG Encryption
+
+```bash
+# Set and encrypt a value with GPG
+dotenvx set SECRET_KEY "myvalue" --gpg --gpg-key user@example.com
+
+# Set in specific file
+dotenvx set -f .env.production DB_PASSWORD "secret" --gpg --gpg-key user@example.com
+```
+
+### Decrypt (Auto-detects GPG)
+
+```bash
+# Decrypt automatically detects gpg:encrypted: prefix
+dotenvx decrypt
+
+# Decrypt specific file
+dotenvx decrypt -f .env.production
+```
+
+### Run with GPG-encrypted .env
+
+```bash
+# Run command - YubiKey PIN will be prompted if needed
+dotenvx run -- node app.js
+
+# Run with specific env file
+dotenvx run -f .env.production -- npm start
+```
+
+### Environment Variables
+
+```bash
+# Set default crypto provider
+export DOTENVX_CRYPTO=gpg
+
+# Set default GPG recipient
+export DOTENV_GPG_KEY=user@example.com
+
+# Environment-specific recipients
+export DOTENV_GPG_KEY_PRODUCTION=prod-team@example.com
+export DOTENV_GPG_KEY_STAGING=staging-team@example.com
+```
+
+### Programmatic API
+
+```javascript
+const dotenvx = require('@dotenvx/dotenvx')
+
+// Check GPG availability
+const gpg = dotenvx.gpgAvailable()
+console.log(gpg) // { available: true, version: '2.4.0', bin: 'gpg', error: null }
+
+// Set with GPG encryption
+dotenvx.set('API_KEY', 'secret', {
+  gpg: true,
+  gpgKey: 'user@example.com'
+})
+```
+
+---
+
+## Encrypted File Format
+
+### GPG-encrypted .env file
+
+```bash
+#/-------------------[DOTENV_GPG_KEY]------------------------/
+#/            GPG/YubiKey encryption for .env files          /
+#/       [how it works](https://dotenvx.com/encryption)      /
+#/----------------------------------------------------------/
+DOTENV_GPG_KEY="user@example.com"
+
+# .env
+SECRET_KEY="gpg:encrypted:hQIMA8T7l1mAU4JvARAA..."
+API_TOKEN="gpg:encrypted:hQIMA8T7l1mAU4JvARAB..."
+```
+
+---
+
+## Test Results
+
+```
+# { total: 2435, pass: 2435 }
+# time=15975.845ms
+```
+
+All tests pass including:
+- Existing ECIES encryption tests (unchanged behavior)
+- New GPG helper tests
+- CLI action tests
+- Service layer tests
+- E2E tests
+
+---
+
+## Known Limitations
+
+1. **GPG must be installed** - The implementation requires GPG CLI (`gpg` or `gpg2`) to be available in PATH
+
+2. **YubiKey PIN prompts** - When using hardware keys, PIN prompts are handled by GPG agent. The 60-second timeout allows time for PIN entry.
+
+3. **No key management** - This implementation doesn't manage GPG keys; users must have their GPG keyring configured
+
+4. **Recipient trust** - Uses `--trust-model always` to avoid interactive trust prompts during encryption
+
+---
+
+## Future Enhancements (Not Implemented)
+
+- `dotenvx gpg:status` - Show GPG configuration status
+- `dotenvx gpg:test` - Test encryption/decryption with current key
+- GUI PIN entry integration for non-TTY environments
+- Support for multiple recipients (encrypt for team)

--- a/claude-docs/01-add-yubikey-gpg-support/TODO-add-yubikey-gpg-support.md
+++ b/claude-docs/01-add-yubikey-gpg-support/TODO-add-yubikey-gpg-support.md
@@ -1,0 +1,4 @@
+I want you to extend dotenvx and add support for YubiKey + GPG keys for encryption and decryption of environment variables. Create a detailed implementatio plan for yourself outlining the steps needed to implement this feature, including any necessary changes to the architecture, commands, and key entry points. Additionally, identify potential challenges and how to address them.
+In case of doubts or several options ask me.
+Write the plan in markdown format to a file.
+ULTRATHINK!

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -114,6 +114,8 @@ program.command('set')
   .option('-fk, --env-keys-file <path>', 'path to your .env.keys file (default: same path as your env file)')
   .option('-c, --encrypt', 'encrypt value', true)
   .option('-p, --plain', 'store value as plain text', false)
+  .option('--gpg', 'use GPG encryption instead of ECIES (YubiKey compatible)')
+  .option('--gpg-key <recipient>', 'GPG key ID, fingerprint, or email for encryption')
   .action(function (...args) {
     this.envs = envs
     setAction.apply(this, args)
@@ -128,6 +130,8 @@ program.command('encrypt')
   .option('-k, --key <keys...>', 'keys(s) to encrypt (default: all keys in file)')
   .option('-ek, --exclude-key <excludeKeys...>', 'keys(s) to exclude from encryption (default: none)')
   .option('--stdout', 'send to stdout')
+  .option('--gpg', 'use GPG encryption instead of ECIES (YubiKey compatible)')
+  .option('--gpg-key <recipient>', 'GPG key ID, fingerprint, or email for encryption')
   .action(function (...args) {
     this.envs = envs
     encryptAction.apply(this, args)
@@ -142,6 +146,7 @@ program.command('decrypt')
   .option('-k, --key <keys...>', 'keys(s) to decrypt (default: all keys in file)')
   .option('-ek, --exclude-key <excludeKeys...>', 'keys(s) to exclude from decryption (default: none)')
   .option('--stdout', 'send to stdout')
+  .option('--gpg', 'expect GPG-encrypted values (auto-detected, YubiKey PIN may be prompted)')
   .action(function (...args) {
     this.envs = envs
     decryptAction.apply(this, args)

--- a/src/lib/helpers/decryptKeyValue.js
+++ b/src/lib/helpers/decryptKeyValue.js
@@ -1,10 +1,17 @@
 const { decrypt } = require('eciesjs')
 
 const Errors = require('./errors')
+const isGpgEncrypted = require('./isGpgEncrypted')
+const gpgDecryptValue = require('./gpgDecryptValue')
 
 const PREFIX = 'encrypted:'
 
 function decryptKeyValue (key, value, privateKeyName, privateKey) {
+  // Handle GPG-encrypted values first
+  if (isGpgEncrypted(value)) {
+    return gpgDecryptValue(key, value)
+  }
+
   let decryptedValue
   let decryptionError
 

--- a/src/lib/helpers/errors.js
+++ b/src/lib/helpers/errors.js
@@ -107,6 +107,73 @@ class Errors {
     e.help = help
     return e
   }
+
+  // GPG-specific errors
+  missingGpgRecipient () {
+    const code = 'MISSING_GPG_RECIPIENT'
+    const message = `[${code}] GPG recipient (key ID or email) is required`
+    const help = `[${code}] Set DOTENV_GPG_KEY environment variable or use --gpg-key flag`
+
+    const e = new Error(message)
+    e.code = code
+    e.help = help
+    return e
+  }
+
+  gpgNotAvailable () {
+    const code = 'GPG_NOT_AVAILABLE'
+    const message = `[${code}] gpg command not found`
+    const help = `[${code}] Install GnuPG: https://gnupg.org/download/`
+
+    const e = new Error(message)
+    e.code = code
+    e.help = help
+    return e
+  }
+
+  gpgEncryptionFailed () {
+    const code = 'GPG_ENCRYPTION_FAILED'
+    const message = `[${code}] GPG encryption failed: ${this.message}`
+    const help = `[${code}] Check GPG key availability: gpg --list-keys`
+
+    const e = new Error(message)
+    e.code = code
+    e.help = help
+    return e
+  }
+
+  gpgDecryptionFailed () {
+    const code = 'GPG_DECRYPTION_FAILED'
+    const message = `[${code}] Unable to decrypt '${this.key}': ${this.message}`
+    const help = `[${code}] Ensure YubiKey is inserted and correct PIN is used`
+
+    const e = new Error(message)
+    e.code = code
+    e.help = help
+    return e
+  }
+
+  yubiKeyNotPresent () {
+    const code = 'YUBIKEY_NOT_PRESENT'
+    const message = `[${code}] YubiKey required for decryption of '${this.key}'`
+    const help = `[${code}] Insert your YubiKey and try again`
+
+    const e = new Error(message)
+    e.code = code
+    e.help = help
+    return e
+  }
+
+  gpgBadPin () {
+    const code = 'GPG_BAD_PIN'
+    const message = `[${code}] Incorrect PIN for decryption of '${this.key}'`
+    const help = `[${code}] Enter correct PIN. After 3 failed attempts, YubiKey may be locked.`
+
+    const e = new Error(message)
+    e.code = code
+    e.help = help
+    return e
+  }
 }
 
 module.exports = Errors

--- a/src/lib/helpers/getCryptoProvider.js
+++ b/src/lib/helpers/getCryptoProvider.js
@@ -1,0 +1,24 @@
+/**
+ * Determine which crypto provider to use
+ * Priority: 1. --gpg flag (options.gpg), 2. DOTENVX_CRYPTO env, 3. default 'ecies'
+ * @param {object} options - Options object
+ * @param {boolean} [options.gpg] - Whether --gpg flag was set
+ * @returns {'ecies' | 'gpg'}
+ */
+function getCryptoProvider (options = {}) {
+  // Explicit --gpg flag takes highest priority
+  if (options.gpg === true) {
+    return 'gpg'
+  }
+
+  // Check environment variable
+  const envCrypto = process.env.DOTENVX_CRYPTO
+  if (envCrypto === 'gpg') {
+    return 'gpg'
+  }
+
+  // Default to ECIES
+  return 'ecies'
+}
+
+module.exports = getCryptoProvider

--- a/src/lib/helpers/getGpgRecipient.js
+++ b/src/lib/helpers/getGpgRecipient.js
@@ -1,0 +1,42 @@
+/**
+ * Get GPG recipient (key ID, fingerprint, or email) from options or environment
+ * Priority: 1. --gpg-key flag, 2. DOTENV_GPG_KEY_<ENV> env, 3. DOTENV_GPG_KEY env
+ * @param {object} options - Options object
+ * @param {string} [options.gpgKey] - GPG key from --gpg-key flag
+ * @param {string} [envFilepath] - Path to env file for environment-specific key lookup
+ * @returns {string|null}
+ */
+function getGpgRecipient (options = {}, envFilepath = null) {
+  // Check --gpg-key flag
+  if (options.gpgKey) {
+    return options.gpgKey
+  }
+
+  // Check environment variables
+  // Support environment-specific keys: DOTENV_GPG_KEY_PRODUCTION, etc.
+  if (envFilepath) {
+    const envSuffix = getEnvSuffix(envFilepath)
+    if (envSuffix) {
+      const envSpecificKey = process.env[`DOTENV_GPG_KEY_${envSuffix.toUpperCase()}`]
+      if (envSpecificKey) {
+        return envSpecificKey
+      }
+    }
+  }
+
+  // Fallback to generic key
+  return process.env.DOTENV_GPG_KEY || null
+}
+
+/**
+ * Extract environment suffix from filepath
+ * @param {string} envFilepath - Path like .env.production
+ * @returns {string|null}
+ */
+function getEnvSuffix (envFilepath) {
+  // Extract environment from filepath like .env.production → production
+  const match = envFilepath.match(/\.env\.(.+)$/)
+  return match ? match[1] : null
+}
+
+module.exports = getGpgRecipient

--- a/src/lib/helpers/gpgAvailable.js
+++ b/src/lib/helpers/gpgAvailable.js
@@ -1,0 +1,38 @@
+const { execSync } = require('child_process')
+
+/**
+ * Check if gpg CLI is available
+ * @returns {{ available: boolean, version: string|null, error: string|null, bin: string|null }}
+ */
+function gpgAvailable () {
+  // Try gpg first, then gpg2 (common on some Linux distros)
+  const binaries = ['gpg', 'gpg2']
+
+  for (const bin of binaries) {
+    try {
+      const version = execSync(`${bin} --version`, {
+        encoding: 'utf8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+      const match = version.match(/gpg \(GnuPG\) (\d+\.\d+(?:\.\d+)?)/)
+      return {
+        available: true,
+        version: match ? match[1] : 'unknown',
+        error: null,
+        bin
+      }
+    } catch (_e) {
+      // Try next binary
+    }
+  }
+
+  return {
+    available: false,
+    version: null,
+    error: 'gpg not found. Install GnuPG: https://gnupg.org/download/',
+    bin: null
+  }
+}
+
+module.exports = gpgAvailable

--- a/src/lib/helpers/gpgDecryptValue.js
+++ b/src/lib/helpers/gpgDecryptValue.js
@@ -1,0 +1,100 @@
+const { spawnSync } = require('child_process')
+const gpgAvailable = require('./gpgAvailable')
+
+const GPG_PREFIX = 'gpg:encrypted:'
+
+/**
+ * Decrypt a GPG-encrypted value
+ * For YubiKey: will trigger PIN prompt via gpg-agent
+ * @param {string} key - The environment variable key (for error messages)
+ * @param {string} value - The encrypted value with gpg:encrypted: prefix
+ * @returns {string} Decrypted plaintext value
+ */
+function gpgDecryptValue (key, value) {
+  if (!value.startsWith(GPG_PREFIX)) {
+    return value
+  }
+
+  // Check GPG availability
+  const gpg = gpgAvailable()
+  if (!gpg.available) {
+    const error = new Error(`[GPG_NOT_AVAILABLE] ${gpg.error}`)
+    error.code = 'GPG_NOT_AVAILABLE'
+    error.help = '[GPG_NOT_AVAILABLE] Install GnuPG: https://gnupg.org/download/'
+    throw error
+  }
+
+  const base64 = value.substring(GPG_PREFIX.length)
+  const armoredCiphertext = wrapInArmor(base64)
+
+  try {
+    // gpg-agent handles PIN prompts for YubiKey
+    // --quiet: suppress extra output
+    // Note: NOT using --batch to allow PIN prompts
+    const result = spawnSync(gpg.bin, ['--decrypt', '--quiet'], {
+      input: armoredCiphertext,
+      encoding: 'utf8',
+      timeout: 60000, // 60s timeout for YubiKey PIN entry
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+
+    if (result.status !== 0) {
+      const stderr = result.stderr || ''
+
+      // Check for common YubiKey errors
+      if (stderr.includes('card error') || stderr.includes('No secret key')) {
+        const error = new Error(`[YUBIKEY_NOT_PRESENT] YubiKey required for decryption of '${key}'`)
+        error.code = 'YUBIKEY_NOT_PRESENT'
+        error.help = '[YUBIKEY_NOT_PRESENT] Insert your YubiKey and try again'
+        throw error
+      }
+
+      if (stderr.includes('Bad PIN') || stderr.includes('PIN blocked')) {
+        const error = new Error(`[GPG_BAD_PIN] Incorrect PIN for decryption of '${key}'`)
+        error.code = 'GPG_BAD_PIN'
+        error.help = '[GPG_BAD_PIN] Enter correct PIN. After 3 failed attempts, YubiKey may be locked.'
+        throw error
+      }
+
+      throw new Error(stderr || 'Decryption failed')
+    }
+
+    return result.stdout
+  } catch (e) {
+    // Re-throw known errors
+    if (e.code === 'GPG_NOT_AVAILABLE' || e.code === 'YUBIKEY_NOT_PRESENT' || e.code === 'GPG_BAD_PIN') {
+      throw e
+    }
+
+    const error = new Error(`[GPG_DECRYPTION_FAILED] Unable to decrypt '${key}': ${e.message}`)
+    error.code = 'GPG_DECRYPTION_FAILED'
+    error.help = [
+      '[GPG_DECRYPTION_FAILED] Possible causes:',
+      '  1. YubiKey not inserted',
+      '  2. Wrong PIN entered',
+      '  3. GPG key not available',
+      `  Debug: ${gpg.bin} --decrypt --verbose`
+    ].join('\n')
+    throw error
+  }
+}
+
+/**
+ * Wrap base64 content in PGP ASCII armor
+ * @param {string} base64 - Base64 encoded content
+ * @returns {string} Full ASCII armored PGP message
+ */
+function wrapInArmor (base64) {
+  // Split into 64-character lines (PGP standard)
+  const lines = base64.match(/.{1,64}/g) || [base64]
+  return [
+    '-----BEGIN PGP MESSAGE-----',
+    '',
+    ...lines,
+    '-----END PGP MESSAGE-----'
+  ].join('\n')
+}
+
+module.exports = gpgDecryptValue
+module.exports.GPG_PREFIX = GPG_PREFIX
+module.exports.wrapInArmor = wrapInArmor

--- a/src/lib/helpers/gpgEncryptValue.js
+++ b/src/lib/helpers/gpgEncryptValue.js
@@ -1,0 +1,88 @@
+const { spawnSync } = require('child_process')
+const gpgAvailable = require('./gpgAvailable')
+
+const GPG_PREFIX = 'gpg:encrypted:'
+
+/**
+ * Encrypt a value using GPG
+ * @param {string} value - The value to encrypt
+ * @param {string} recipient - GPG key ID, fingerprint, or email
+ * @returns {string} Encrypted value with gpg:encrypted: prefix
+ */
+function gpgEncryptValue (value, recipient) {
+  // Validate recipient
+  if (!recipient) {
+    const error = new Error('[MISSING_GPG_RECIPIENT] GPG recipient (key ID or email) is required')
+    error.code = 'MISSING_GPG_RECIPIENT'
+    error.help = '[MISSING_GPG_RECIPIENT] Set DOTENV_GPG_KEY environment variable or use --gpg-key flag'
+    throw error
+  }
+
+  // Check GPG availability
+  const gpg = gpgAvailable()
+  if (!gpg.available) {
+    const error = new Error(`[GPG_NOT_AVAILABLE] ${gpg.error}`)
+    error.code = 'GPG_NOT_AVAILABLE'
+    error.help = '[GPG_NOT_AVAILABLE] Install GnuPG: https://gnupg.org/download/'
+    throw error
+  }
+
+  try {
+    // --armor: ASCII output
+    // --trust-model always: skip trust db check (useful for CI)
+    // --batch: non-interactive
+    // --yes: overwrite without prompt
+    const result = spawnSync(gpg.bin, [
+      '--encrypt',
+      '--armor',
+      '--recipient', recipient,
+      '--trust-model', 'always',
+      '--batch',
+      '--yes'
+    ], {
+      input: value,
+      encoding: 'utf8',
+      timeout: 30000, // 30s timeout
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+
+    if (result.status !== 0) {
+      const stderr = result.stderr || ''
+      throw new Error(stderr || 'GPG encryption failed')
+    }
+
+    // Extract base64 from ASCII armor
+    const base64 = extractBase64FromArmor(result.stdout)
+    return `${GPG_PREFIX}${base64}`
+  } catch (e) {
+    if (e.code === 'MISSING_GPG_RECIPIENT' || e.code === 'GPG_NOT_AVAILABLE') {
+      throw e
+    }
+
+    const error = new Error(`[GPG_ENCRYPTION_FAILED] GPG encryption failed: ${e.message}`)
+    error.code = 'GPG_ENCRYPTION_FAILED'
+    error.help = `[GPG_ENCRYPTION_FAILED] Verify GPG key exists: ${gpg.bin} --list-keys ${recipient}`
+    throw error
+  }
+}
+
+/**
+ * Extract base64 content from PGP ASCII armor
+ * @param {string} armoredText - Full ASCII armored PGP message
+ * @returns {string} Base64 encoded content without headers/footers
+ */
+function extractBase64FromArmor (armoredText) {
+  const lines = armoredText.split('\n')
+  const dataLines = lines.filter(line =>
+    !line.startsWith('-----') &&
+    !line.startsWith('Version:') &&
+    !line.startsWith('Comment:') &&
+    !line.startsWith('Hash:') &&
+    line.trim() !== ''
+  )
+  return dataLines.join('')
+}
+
+module.exports = gpgEncryptValue
+module.exports.GPG_PREFIX = GPG_PREFIX
+module.exports.extractBase64FromArmor = extractBase64FromArmor

--- a/src/lib/helpers/isEncrypted.js
+++ b/src/lib/helpers/isEncrypted.js
@@ -1,7 +1,16 @@
-const ENCRYPTION_PATTERN = /^encrypted:.+/
+const ECIES_PATTERN = /^encrypted:.+/
+const GPG_PATTERN = /^gpg:encrypted:.+/
 
+/**
+ * Check if a value is encrypted (ECIES or GPG)
+ * @param {string} value - The value to check
+ * @returns {boolean}
+ */
 function isEncrypted (value) {
-  return ENCRYPTION_PATTERN.test(value)
+  if (typeof value !== 'string') {
+    return false
+  }
+  return ECIES_PATTERN.test(value) || GPG_PATTERN.test(value)
 }
 
 module.exports = isEncrypted

--- a/src/lib/helpers/isGpgEncrypted.js
+++ b/src/lib/helpers/isGpgEncrypted.js
@@ -1,0 +1,16 @@
+const GPG_PREFIX = 'gpg:encrypted:'
+
+/**
+ * Check if a value is GPG-encrypted
+ * @param {string} value - The value to check
+ * @returns {boolean}
+ */
+function isGpgEncrypted (value) {
+  if (typeof value !== 'string') {
+    return false
+  }
+  return value.startsWith(GPG_PREFIX)
+}
+
+module.exports = isGpgEncrypted
+module.exports.GPG_PREFIX = GPG_PREFIX

--- a/src/lib/main.d.ts
+++ b/src/lib/main.d.ts
@@ -205,6 +205,19 @@ export interface SetOptions {
    * @example require('@dotenvx/dotenvx').config(key, value, { encrypt: false } })
    */
   encrypt?: boolean;
+
+  /**
+   * Use GPG encryption instead of ECIES (YubiKey compatible)
+   * @default false
+   * @example require('@dotenvx/dotenvx').set(key, value, { gpg: true, gpgKey: 'user@example.com' })
+   */
+  gpg?: boolean;
+
+  /**
+   * GPG key ID, fingerprint, or email for encryption
+   * @example require('@dotenvx/dotenvx').set(key, value, { gpg: true, gpgKey: 'user@example.com' })
+   */
+  gpgKey?: string;
 }
 
 export type SetProcessedEnv = {
@@ -220,6 +233,10 @@ export type SetProcessedEnv = {
   privateKeyAdded?: boolean;
   privateKeyName?: string;
   error?: Error;
+  /** Crypto provider used: 'ecies' or 'gpg' */
+  cryptoProvider?: 'ecies' | 'gpg';
+  /** GPG recipient (key ID, fingerprint, or email) when using GPG encryption */
+  gpgRecipient?: string;
 };
 
 export type SetOutput = {
@@ -318,3 +335,22 @@ export function genexample(
   directory: string,
   envFile: string
 ): GenExampleOutput;
+
+export interface GpgAvailableOutput {
+  /** Whether GPG CLI is available */
+  available: boolean;
+  /** GPG version string (e.g., "2.4.0") or null if not available */
+  version: string | null;
+  /** Error message if GPG is not available */
+  error: string | null;
+  /** Binary name used (e.g., "gpg" or "gpg2") */
+  bin: string | null;
+}
+
+/**
+ * Check if GPG CLI is available for GPG/YubiKey encryption
+ *
+ * @returns an object with availability status, version, and potential error
+ * @example const { available, version } = require('@dotenvx/dotenvx').gpgAvailable()
+ */
+export function gpgAvailable(): GpgAvailableOutput;

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -20,6 +20,7 @@ const buildEnvs = require('./helpers/buildEnvs')
 const Parse = require('./helpers/parse')
 const fsx = require('./helpers/fsx')
 const isIgnoringDotenvKeys = require('./helpers/isIgnoringDotenvKeys')
+const gpgAvailable = require('./helpers/gpgAvailable')
 
 /** @type {import('./main').config} */
 const config = function (options = {}) {
@@ -191,11 +192,17 @@ const set = function (key, value, options = {}) {
   const envs = buildEnvs(options)
   const envKeysFilepath = options.envKeysFile
 
+  // GPG options
+  const gpgOptions = {
+    gpg: options.gpg,
+    gpgKey: options.gpgKey
+  }
+
   const {
     processedEnvs,
     changedFilepaths,
     unchangedFilepaths
-  } = new Sets(key, value, envs, encrypt, envKeysFilepath).run()
+  } = new Sets(key, value, envs, encrypt, envKeysFilepath, gpgOptions).run()
 
   let withEncryption = ''
 
@@ -333,6 +340,8 @@ module.exports = {
   ls,
   keypair,
   genexample,
+  // GPG/YubiKey support
+  gpgAvailable,
   // expose for libs depending on @dotenvx/dotenvx - like dotenvx-radar
   setLogLevel,
   logger,

--- a/src/lib/services/sets.js
+++ b/src/lib/services/sets.js
@@ -7,6 +7,7 @@ const Errors = require('./../helpers/errors')
 const guessPrivateKeyName = require('./../helpers/guessPrivateKeyName')
 const guessPublicKeyName = require('./../helpers/guessPublicKeyName')
 const encryptValue = require('./../helpers/encryptValue')
+const gpgEncryptValue = require('./../helpers/gpgEncryptValue')
 const decryptKeyValue = require('./../helpers/decryptKeyValue')
 const replace = require('./../helpers/replace')
 const dotenvParse = require('./../helpers/dotenvParse')
@@ -17,14 +18,21 @@ const findPublicKey = require('./../helpers/findPublicKey')
 const keypair = require('./../helpers/keypair')
 const truncate = require('./../helpers/truncate')
 const isEncrypted = require('./../helpers/isEncrypted')
+const isGpgEncrypted = require('./../helpers/isGpgEncrypted')
+const getCryptoProvider = require('./../helpers/getCryptoProvider')
+const getGpgRecipient = require('./../helpers/getGpgRecipient')
 
 class Sets {
-  constructor (key, value, envs = [], encrypt = true, envKeysFilepath = null) {
+  constructor (key, value, envs = [], encrypt = true, envKeysFilepath = null, options = {}) {
     this.envs = determineEnvs(envs, process.env)
     this.key = key
     this.value = value
     this.encrypt = encrypt
     this.envKeysFilepath = envKeysFilepath
+    this.options = options
+
+    // Determine crypto provider
+    this.cryptoProvider = getCryptoProvider(options)
 
     this.processedEnvs = []
     this.changedFilepaths = new Set()
@@ -69,97 +77,130 @@ class Sets {
       const envParsed = dotenvParse(envSrc)
       row.originalValue = envParsed[row.key] || null
       const wasPlainText = !isEncrypted(row.originalValue)
+      const wasGpgEncrypted = isGpgEncrypted(row.originalValue)
       this.readableFilepaths.add(envFilepath)
 
       if (this.encrypt) {
-        let publicKey
-        let privateKey
-
-        const publicKeyName = guessPublicKeyName(envFilepath)
-        const privateKeyName = guessPrivateKeyName(envFilepath)
-        const existingPrivateKey = findPrivateKey(envFilepath, this.envKeysFilepath)
-        const existingPublicKey = findPublicKey(envFilepath)
-
-        let envKeysFilepath = path.join(path.dirname(filepath), '.env.keys')
-        if (this.envKeysFilepath) {
-          envKeysFilepath = path.resolve(this.envKeysFilepath)
-        }
-        const relativeFilepath = path.relative(path.dirname(filepath), envKeysFilepath)
-
-        if (existingPrivateKey) {
-          const kp = keypair(existingPrivateKey)
-          publicKey = kp.publicKey
-          privateKey = kp.privateKey
-
-          if (row.originalValue) {
-            row.originalValue = decryptKeyValue(row.key, row.originalValue, privateKeyName, privateKey)
+        // GPG encryption mode
+        if (this.cryptoProvider === 'gpg') {
+          const gpgRecipient = getGpgRecipient(this.options, envFilepath)
+          if (!gpgRecipient) {
+            throw new Errors({}).missingGpgRecipient()
           }
 
-          // if derivation doesn't match what's in the file (or preset in env)
-          if (existingPublicKey && existingPublicKey !== publicKey) {
-            const error = new Error(`derived public key (${truncate(publicKey)}) does not match the existing public key (${truncate(existingPublicKey)})`)
-            error.code = 'INVALID_DOTENV_PRIVATE_KEY'
-            error.help = `debug info: ${privateKeyName}=${truncate(existingPrivateKey)} (derived ${publicKeyName}=${truncate(publicKey)} vs existing ${publicKeyName}=${truncate(existingPublicKey)})`
-            throw error
+          row.gpgRecipient = gpgRecipient
+          row.cryptoProvider = 'gpg'
+
+          // Decrypt original value if GPG-encrypted (for comparison)
+          if (wasGpgEncrypted && row.originalValue) {
+            row.originalValue = decryptKeyValue(row.key, row.originalValue, null, null)
           }
 
-          // typical scenario when encrypting a monorepo second .env file from a prior generated -fk .env.keys file
-          if (!existingPublicKey) {
+          // Check if DOTENV_GPG_KEY header needs to be added
+          const gpgKeyName = this._guessGpgKeyName(envFilepath)
+          const existingGpgKey = envParsed[gpgKeyName]
+
+          if (!existingGpgKey) {
             const ps = this._preserveShebang(envSrc)
             const firstLinePreserved = ps.firstLinePreserved
             envSrc = ps.envSrc
 
+            const prependGpgKey = this._prependGpgKey(gpgKeyName, gpgRecipient, filename)
+            envSrc = `${firstLinePreserved}${prependGpgKey}\n${envSrc}`
+          }
+
+          row.encryptedValue = gpgEncryptValue(this.value, gpgRecipient)
+        } else {
+          // ECIES encryption mode (existing logic)
+          let publicKey
+          let privateKey
+
+          const publicKeyName = guessPublicKeyName(envFilepath)
+          const privateKeyName = guessPrivateKeyName(envFilepath)
+          const existingPrivateKey = findPrivateKey(envFilepath, this.envKeysFilepath)
+          const existingPublicKey = findPublicKey(envFilepath)
+
+          let envKeysFilepath = path.join(path.dirname(filepath), '.env.keys')
+          if (this.envKeysFilepath) {
+            envKeysFilepath = path.resolve(this.envKeysFilepath)
+          }
+          const relativeFilepath = path.relative(path.dirname(filepath), envKeysFilepath)
+
+          if (existingPrivateKey) {
+            const kp = keypair(existingPrivateKey)
+            publicKey = kp.publicKey
+            privateKey = kp.privateKey
+
+            if (row.originalValue) {
+              row.originalValue = decryptKeyValue(row.key, row.originalValue, privateKeyName, privateKey)
+            }
+
+            // if derivation doesn't match what's in the file (or preset in env)
+            if (existingPublicKey && existingPublicKey !== publicKey) {
+              const error = new Error(`derived public key (${truncate(publicKey)}) does not match the existing public key (${truncate(existingPublicKey)})`)
+              error.code = 'INVALID_DOTENV_PRIVATE_KEY'
+              error.help = `debug info: ${privateKeyName}=${truncate(existingPrivateKey)} (derived ${publicKeyName}=${truncate(publicKey)} vs existing ${publicKeyName}=${truncate(existingPublicKey)})`
+              throw error
+            }
+
+            // typical scenario when encrypting a monorepo second .env file from a prior generated -fk .env.keys file
+            if (!existingPublicKey) {
+              const ps = this._preserveShebang(envSrc)
+              const firstLinePreserved = ps.firstLinePreserved
+              envSrc = ps.envSrc
+
+              const prependPublicKey = this._prependPublicKey(publicKeyName, publicKey, filename, relativeFilepath)
+
+              envSrc = `${firstLinePreserved}${prependPublicKey}\n${envSrc}`
+            }
+          } else if (existingPublicKey) {
+            publicKey = existingPublicKey
+          } else {
+            // .env.keys
+            let keysSrc = ''
+            if (fsx.existsSync(envKeysFilepath)) {
+              keysSrc = fsx.readFileX(envKeysFilepath)
+            }
+
+            const ps = this._preserveShebang(envSrc)
+            const firstLinePreserved = ps.firstLinePreserved
+            envSrc = ps.envSrc
+
+            const kp = keypair() // generates a fresh keypair in memory
+            publicKey = kp.publicKey
+            privateKey = kp.privateKey
+
             const prependPublicKey = this._prependPublicKey(publicKeyName, publicKey, filename, relativeFilepath)
 
+            // privateKey
+            const firstTimeKeysSrc = [
+              '#/------------------!DOTENV_PRIVATE_KEYS!-------------------/',
+              '#/ private decryption keys. DO NOT commit to source control /',
+              '#/     [how it works](https://dotenvx.com/encryption)       /',
+              '#/----------------------------------------------------------/'
+            ].join('\n')
+            const appendPrivateKey = [
+              `# ${filename}`,
+              `${privateKeyName}=${privateKey}`,
+              ''
+            ].join('\n')
+
             envSrc = `${firstLinePreserved}${prependPublicKey}\n${envSrc}`
+            keysSrc = keysSrc.length > 1 ? keysSrc : `${firstTimeKeysSrc}\n`
+            keysSrc = `${keysSrc}\n${appendPrivateKey}`
+
+            // write to .env.keys
+            fsx.writeFileX(envKeysFilepath, keysSrc)
+
+            row.privateKeyAdded = true
+            row.envKeysFilepath = this.envKeysFilepath || path.join(path.dirname(envFilepath), path.basename(envKeysFilepath))
           }
-        } else if (existingPublicKey) {
-          publicKey = existingPublicKey
-        } else {
-          // .env.keys
-          let keysSrc = ''
-          if (fsx.existsSync(envKeysFilepath)) {
-            keysSrc = fsx.readFileX(envKeysFilepath)
-          }
 
-          const ps = this._preserveShebang(envSrc)
-          const firstLinePreserved = ps.firstLinePreserved
-          envSrc = ps.envSrc
-
-          const kp = keypair() // generates a fresh keypair in memory
-          publicKey = kp.publicKey
-          privateKey = kp.privateKey
-
-          const prependPublicKey = this._prependPublicKey(publicKeyName, publicKey, filename, relativeFilepath)
-
-          // privateKey
-          const firstTimeKeysSrc = [
-            '#/------------------!DOTENV_PRIVATE_KEYS!-------------------/',
-            '#/ private decryption keys. DO NOT commit to source control /',
-            '#/     [how it works](https://dotenvx.com/encryption)       /',
-            '#/----------------------------------------------------------/'
-          ].join('\n')
-          const appendPrivateKey = [
-            `# ${filename}`,
-            `${privateKeyName}=${privateKey}`,
-            ''
-          ].join('\n')
-
-          envSrc = `${firstLinePreserved}${prependPublicKey}\n${envSrc}`
-          keysSrc = keysSrc.length > 1 ? keysSrc : `${firstTimeKeysSrc}\n`
-          keysSrc = `${keysSrc}\n${appendPrivateKey}`
-
-          // write to .env.keys
-          fsx.writeFileX(envKeysFilepath, keysSrc)
-
-          row.privateKeyAdded = true
-          row.envKeysFilepath = this.envKeysFilepath || path.join(path.dirname(envFilepath), path.basename(envKeysFilepath))
+          row.publicKey = publicKey
+          row.privateKey = privateKey
+          row.encryptedValue = encryptValue(this.value, publicKey)
+          row.privateKeyName = privateKeyName
         }
-
-        row.publicKey = publicKey
-        row.privateKey = privateKey
-        row.encryptedValue = encryptValue(this.value, publicKey)
-        row.privateKeyName = privateKeyName
       }
 
       const goingFromPlainTextToEncrypted = wasPlainText && this.encrypt
@@ -200,6 +241,29 @@ class Sets {
       '',
       `# ${filename}`
     ].join('\n')
+  }
+
+  _prependGpgKey (gpgKeyName, gpgRecipient, filename) {
+    return [
+      '#/-------------------[DOTENV_GPG_KEY]------------------------/',
+      '#/            GPG/YubiKey encryption for .env files          /',
+      '#/       [how it works](https://dotenvx.com/encryption)      /',
+      '#/----------------------------------------------------------/',
+      `${gpgKeyName}="${gpgRecipient}"`,
+      '',
+      `# ${filename}`
+    ].join('\n')
+  }
+
+  _guessGpgKeyName (envFilepath) {
+    // Similar to guessPublicKeyName but for GPG
+    // .env -> DOTENV_GPG_KEY
+    // .env.production -> DOTENV_GPG_KEY_PRODUCTION
+    const match = envFilepath.match(/\.env\.(.+)$/)
+    if (match) {
+      return `DOTENV_GPG_KEY_${match[1].toUpperCase()}`
+    }
+    return 'DOTENV_GPG_KEY'
   }
 
   _preserveShebang (envSrc) {

--- a/tests/lib/helpers/getCryptoProvider.test.js
+++ b/tests/lib/helpers/getCryptoProvider.test.js
@@ -1,0 +1,76 @@
+const t = require('tap')
+
+const getCryptoProvider = require('../../../src/lib/helpers/getCryptoProvider')
+
+t.test('#getCryptoProvider', ct => {
+  const originalEnv = process.env.DOTENVX_CRYPTO
+
+  ct.afterEach(() => {
+    // Restore original env
+    if (originalEnv === undefined) {
+      delete process.env.DOTENVX_CRYPTO
+    } else {
+      process.env.DOTENVX_CRYPTO = originalEnv
+    }
+  })
+
+  ct.test('returns ecies by default', ct => {
+    delete process.env.DOTENVX_CRYPTO
+    const result = getCryptoProvider()
+    ct.equal(result, 'ecies')
+    ct.end()
+  })
+
+  ct.test('returns ecies when options is empty', ct => {
+    delete process.env.DOTENVX_CRYPTO
+    const result = getCryptoProvider({})
+    ct.equal(result, 'ecies')
+    ct.end()
+  })
+
+  ct.test('returns gpg when options.gpg is true', ct => {
+    delete process.env.DOTENVX_CRYPTO
+    const result = getCryptoProvider({ gpg: true })
+    ct.equal(result, 'gpg')
+    ct.end()
+  })
+
+  ct.test('returns ecies when options.gpg is false', ct => {
+    delete process.env.DOTENVX_CRYPTO
+    const result = getCryptoProvider({ gpg: false })
+    ct.equal(result, 'ecies')
+    ct.end()
+  })
+
+  ct.test('returns gpg when DOTENVX_CRYPTO=gpg', ct => {
+    process.env.DOTENVX_CRYPTO = 'gpg'
+    const result = getCryptoProvider({})
+    ct.equal(result, 'gpg')
+    ct.end()
+  })
+
+  ct.test('options.gpg=true takes precedence over DOTENVX_CRYPTO=ecies', ct => {
+    delete process.env.DOTENVX_CRYPTO
+    const result = getCryptoProvider({ gpg: true })
+    ct.equal(result, 'gpg')
+    ct.end()
+  })
+
+  ct.test('options.gpg=false does not override DOTENVX_CRYPTO=gpg', ct => {
+    process.env.DOTENVX_CRYPTO = 'gpg'
+    // When gpg=false is passed, it doesn't explicitly disable gpg from env
+    // The env var still takes effect (this is the design choice)
+    const result = getCryptoProvider({ gpg: false })
+    ct.equal(result, 'gpg')
+    ct.end()
+  })
+
+  ct.test('returns ecies when DOTENVX_CRYPTO has invalid value', ct => {
+    process.env.DOTENVX_CRYPTO = 'invalid'
+    const result = getCryptoProvider({})
+    ct.equal(result, 'ecies')
+    ct.end()
+  })
+
+  ct.end()
+})

--- a/tests/lib/helpers/getGpgRecipient.test.js
+++ b/tests/lib/helpers/getGpgRecipient.test.js
@@ -1,0 +1,82 @@
+const t = require('tap')
+
+const getGpgRecipient = require('../../../src/lib/helpers/getGpgRecipient')
+
+t.test('#getGpgRecipient', ct => {
+  const originalGpgKey = process.env.DOTENV_GPG_KEY
+  const originalGpgKeyProd = process.env.DOTENV_GPG_KEY_PRODUCTION
+
+  ct.afterEach(() => {
+    // Restore original env
+    if (originalGpgKey === undefined) {
+      delete process.env.DOTENV_GPG_KEY
+    } else {
+      process.env.DOTENV_GPG_KEY = originalGpgKey
+    }
+    if (originalGpgKeyProd === undefined) {
+      delete process.env.DOTENV_GPG_KEY_PRODUCTION
+    } else {
+      process.env.DOTENV_GPG_KEY_PRODUCTION = originalGpgKeyProd
+    }
+  })
+
+  ct.test('returns null when no recipient specified', ct => {
+    delete process.env.DOTENV_GPG_KEY
+    const result = getGpgRecipient({})
+    ct.equal(result, null)
+    ct.end()
+  })
+
+  ct.test('returns gpgKey from options', ct => {
+    delete process.env.DOTENV_GPG_KEY
+    const result = getGpgRecipient({ gpgKey: 'user@example.com' })
+    ct.equal(result, 'user@example.com')
+    ct.end()
+  })
+
+  ct.test('returns DOTENV_GPG_KEY from env', ct => {
+    process.env.DOTENV_GPG_KEY = 'env-user@example.com'
+    const result = getGpgRecipient({})
+    ct.equal(result, 'env-user@example.com')
+    ct.end()
+  })
+
+  ct.test('options.gpgKey takes precedence over env', ct => {
+    process.env.DOTENV_GPG_KEY = 'env-user@example.com'
+    const result = getGpgRecipient({ gpgKey: 'option-user@example.com' })
+    ct.equal(result, 'option-user@example.com')
+    ct.end()
+  })
+
+  ct.test('returns environment-specific key for .env.production', ct => {
+    delete process.env.DOTENV_GPG_KEY
+    process.env.DOTENV_GPG_KEY_PRODUCTION = 'prod-user@example.com'
+    const result = getGpgRecipient({}, '.env.production')
+    ct.equal(result, 'prod-user@example.com')
+    ct.end()
+  })
+
+  ct.test('falls back to generic DOTENV_GPG_KEY if env-specific not found', ct => {
+    process.env.DOTENV_GPG_KEY = 'generic@example.com'
+    delete process.env.DOTENV_GPG_KEY_PRODUCTION
+    const result = getGpgRecipient({}, '.env.production')
+    ct.equal(result, 'generic@example.com')
+    ct.end()
+  })
+
+  ct.test('options.gpgKey takes precedence over env-specific key', ct => {
+    process.env.DOTENV_GPG_KEY_PRODUCTION = 'prod-user@example.com'
+    const result = getGpgRecipient({ gpgKey: 'option@example.com' }, '.env.production')
+    ct.equal(result, 'option@example.com')
+    ct.end()
+  })
+
+  ct.test('handles .env file without environment suffix', ct => {
+    delete process.env.DOTENV_GPG_KEY
+    const result = getGpgRecipient({}, '.env')
+    ct.equal(result, null)
+    ct.end()
+  })
+
+  ct.end()
+})

--- a/tests/lib/helpers/gpgAvailable.test.js
+++ b/tests/lib/helpers/gpgAvailable.test.js
@@ -1,0 +1,79 @@
+const t = require('tap')
+const proxyquire = require('proxyquire').noCallThru()
+
+t.test('#gpgAvailable', ct => {
+  ct.test('returns available=true when gpg is installed', ct => {
+    const gpgAvailable = proxyquire('../../../src/lib/helpers/gpgAvailable', {
+      child_process: {
+        execSync: () => 'gpg (GnuPG) 2.4.0\nlibgcrypt 1.10.1\n'
+      }
+    })
+
+    const result = gpgAvailable()
+
+    ct.equal(result.available, true)
+    ct.equal(result.version, '2.4.0')
+    ct.equal(result.error, null)
+    ct.equal(result.bin, 'gpg')
+    ct.end()
+  })
+
+  ct.test('returns available=true with gpg2 when gpg not found', ct => {
+    let callCount = 0
+    const gpgAvailable = proxyquire('../../../src/lib/helpers/gpgAvailable', {
+      child_process: {
+        execSync: (cmd) => {
+          callCount++
+          if (callCount === 1) {
+            throw new Error('command not found')
+          }
+          return 'gpg (GnuPG) 2.2.19\n'
+        }
+      }
+    })
+
+    const result = gpgAvailable()
+
+    ct.equal(result.available, true)
+    ct.equal(result.version, '2.2.19')
+    ct.equal(result.error, null)
+    ct.equal(result.bin, 'gpg2')
+    ct.end()
+  })
+
+  ct.test('returns available=false when neither gpg nor gpg2 installed', ct => {
+    const gpgAvailable = proxyquire('../../../src/lib/helpers/gpgAvailable', {
+      child_process: {
+        execSync: () => {
+          throw new Error('command not found')
+        }
+      }
+    })
+
+    const result = gpgAvailable()
+
+    ct.equal(result.available, false)
+    ct.equal(result.version, null)
+    ct.ok(result.error.includes('gpg not found'))
+    ct.equal(result.bin, null)
+    ct.end()
+  })
+
+  ct.test('returns version=unknown when version string cannot be parsed', ct => {
+    const gpgAvailable = proxyquire('../../../src/lib/helpers/gpgAvailable', {
+      child_process: {
+        execSync: () => 'some unknown gpg output'
+      }
+    })
+
+    const result = gpgAvailable()
+
+    ct.equal(result.available, true)
+    ct.equal(result.version, 'unknown')
+    ct.equal(result.error, null)
+    ct.equal(result.bin, 'gpg')
+    ct.end()
+  })
+
+  ct.end()
+})

--- a/tests/lib/helpers/isEncrypted.test.js
+++ b/tests/lib/helpers/isEncrypted.test.js
@@ -24,3 +24,27 @@ t.test('#isEncrypted passes null', ct => {
   ct.same(result, false)
   ct.end()
 })
+
+t.test('#isEncrypted GPG encrypted value', ct => {
+  const result = isEncrypted('gpg:encrypted:hQIMA...')
+  ct.same(result, true)
+  ct.end()
+})
+
+t.test('#isEncrypted GPG real world', ct => {
+  const result = isEncrypted('gpg:encrypted:hQIMA8T7l1mAU4JvARAAnxyz...')
+  ct.same(result, true)
+  ct.end()
+})
+
+t.test('#isEncrypted undefined returns false', ct => {
+  const result = isEncrypted(undefined)
+  ct.same(result, false)
+  ct.end()
+})
+
+t.test('#isEncrypted number returns false', ct => {
+  const result = isEncrypted(12345)
+  ct.same(result, false)
+  ct.end()
+})

--- a/tests/lib/helpers/isGpgEncrypted.test.js
+++ b/tests/lib/helpers/isGpgEncrypted.test.js
@@ -1,0 +1,43 @@
+const t = require('tap')
+
+const isGpgEncrypted = require('../../../src/lib/helpers/isGpgEncrypted')
+
+t.test('#isGpgEncrypted', ct => {
+  ct.test('returns true for gpg:encrypted: prefixed value', ct => {
+    const value = 'gpg:encrypted:hQIMA...'
+    ct.equal(isGpgEncrypted(value), true)
+    ct.end()
+  })
+
+  ct.test('returns false for ecies encrypted: prefixed value', ct => {
+    const value = 'encrypted:BE9Y7LKANx77X1pv...'
+    ct.equal(isGpgEncrypted(value), false)
+    ct.end()
+  })
+
+  ct.test('returns false for plain text value', ct => {
+    const value = 'hello world'
+    ct.equal(isGpgEncrypted(value), false)
+    ct.end()
+  })
+
+  ct.test('returns false for empty string', ct => {
+    ct.equal(isGpgEncrypted(''), false)
+    ct.end()
+  })
+
+  ct.test('returns false for non-string values', ct => {
+    ct.equal(isGpgEncrypted(null), false)
+    ct.equal(isGpgEncrypted(undefined), false)
+    ct.equal(isGpgEncrypted(123), false)
+    ct.equal(isGpgEncrypted({}), false)
+    ct.end()
+  })
+
+  ct.test('exports GPG_PREFIX constant', ct => {
+    ct.equal(isGpgEncrypted.GPG_PREFIX, 'gpg:encrypted:')
+    ct.end()
+  })
+
+  ct.end()
+})


### PR DESCRIPTION
  Add support for encrypting .env files using GPG keys, enabling hardware
  security module (HSM) support via YubiKey. This provides an alternative
  to the existing ECIES encryption for users who prefer GPG-based workflows.

  New features:
  - `--gpg` flag for encrypt, decrypt, and set commands
  - `--gpg-key <recipient>` to specify GPG key ID or email
  - `DOTENVX_CRYPTO=gpg` environment variable for persistent config
  - Environment-specific GPG keys (DOTENV_GPG_KEY_PRODUCTION, etc.)
  - Auto-detection of gpg:encrypted: prefix during decryption
  - 60-second timeout for YubiKey PIN entry

  New helpers:
  - gpgAvailable.js - detect GPG CLI installation
  - gpgEncryptValue.js - encrypt values via GPG
  - gpgDecryptValue.js - decrypt values via GPG
  - isGpgEncrypted.js - detect GPG-encrypted values
  - getCryptoProvider.js - determine ECIES vs GPG mode
  - getGpgRecipient.js - resolve GPG recipient from options/env

  Usage:
    dotenvx encrypt --gpg --gpg-key user@example.com dotenvx set KEY "value" --gpg --gpg-key user@example.com dotenvx run -- node app.js  # auto-decrypts, prompts for YubiKey PIN

Demo:

https://github.com/user-attachments/assets/bcf84f42-a31a-4303-828a-57167f405f9c

