### PR TITLE
Make Docker documentation base image agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ Or in any image:
 ```Containerfile
 FROM node:latest
 RUN echo "HELLO=World" > .env && echo "console.log('Hello ' + process.env.HELLO)" > index.js
-COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin
-CMD ["/bin/dotenvx", "run", "--", "echo", "Hello $HELLO"]
+RUN curl -fsS https://dotenvx.sh | sh
+CMD ["/usr/local/bin/dotenvx", "run", "--", "echo", "Hello $HELLO"]
 ```
 
 see [docker guide](https://dotenvx.com/docs/platforms/docker)
@@ -376,7 +376,7 @@ see [github actions guide](https://dotenvx.com/docs/cis/github-actions)
 heroku buildpacks:add https://github.com/dotenvx/heroku-buildpack-dotenvx
 
 # docker
-COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin
+RUN curl -fsS https://dotenvx.sh | sh
 
 # vercel
 npm install @dotenvx/dotenvx --save
@@ -2234,13 +2234,16 @@ Prevent `.env` files from being built into your docker containers.
 Add it to your `Dockerfile`.
 
 ```Containerfile
-# Dockerfile
-COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin
+# Install via script
+RUN curl -fsS https://dotenvx.sh | sh
 
-...
+# Or copy binary from official image
+COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin/local/bin
+
+# ... orther container commands
 
 RUN dotenvx ext prebuild
-CMD ["/bin/dotenvx", "run", "--", "node", "index.js"]
+CMD ["/usr/local/bin/dotenvx", "run", "--", "node", "index.js"]
 ```
 
 </details>
@@ -2251,13 +2254,16 @@ Prevent `.env` files from being built into your docker containers inside a speci
 Add it to your `Dockerfile`.
 
 ```Containerfile
-# Dockerfile
-COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin
+# Install via script
+RUN curl -fsS https://dotenvx.sh | sh
 
-...
+# Or copy binary from official image
+COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin/local/bin
+
+# ... orther container commands
 
 RUN dotenvx ext prebuild apps/backend
-CMD ["/bin/dotenvx", "run", "--", "node", "apps/backend/index.js"]
+CMD ["/usr/local/bin/dotenvx", "run", "--", "node", "apps/backend/index.js"]
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -337,11 +337,11 @@ $ docker run -it --rm -v $(pwd):/app dotenv/dotenvx run -- node index.js
 
 Or in any image:
 
-```sh
+```Containerfile
 FROM node:latest
 RUN echo "HELLO=World" > .env && echo "console.log('Hello ' + process.env.HELLO)" > index.js
-RUN curl -fsS https://dotenvx.sh/install.sh | sh
-CMD ["dotenvx", "run", "--", "echo", "Hello $HELLO"]
+COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin
+CMD ["/bin/dotenvx", "run", "--", "echo", "Hello $HELLO"]
 ```
 
 see [docker guide](https://dotenvx.com/docs/platforms/docker)
@@ -376,7 +376,7 @@ see [github actions guide](https://dotenvx.com/docs/cis/github-actions)
 heroku buildpacks:add https://github.com/dotenvx/heroku-buildpack-dotenvx
 
 # docker
-RUN curl -fsS https://dotenvx.sh/install.sh | sh
+COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin
 
 # vercel
 npm install @dotenvx/dotenvx --save
@@ -2233,14 +2233,14 @@ Prevent `.env` files from being built into your docker containers.
 
 Add it to your `Dockerfile`.
 
-```sh
+```Containerfile
 # Dockerfile
-RUN curl -fsS https://dotenvx.sh | sh
+COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin
 
 ...
 
 RUN dotenvx ext prebuild
-CMD ["dotenvx", "run", "--", "node", "index.js"]
+CMD ["/bin/dotenvx", "run", "--", "node", "index.js"]
 ```
 
 </details>
@@ -2250,14 +2250,14 @@ Prevent `.env` files from being built into your docker containers inside a speci
 
 Add it to your `Dockerfile`.
 
-```sh
+```Containerfile
 # Dockerfile
-RUN curl -fsS https://dotenvx.sh | sh
+COPY --from=dotenv/dotenvx:latest /usr/local/bin/dotenvx /bin
 
 ...
 
 RUN dotenvx ext prebuild apps/backend
-CMD ["dotenvx", "run", "--", "node", "apps/backend/index.js"]
+CMD ["/bin/dotenvx", "run", "--", "node", "apps/backend/index.js"]
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Or in any image:
 ```Containerfile
 FROM node:latest
 RUN echo "HELLO=World" > .env && echo "console.log('Hello ' + process.env.HELLO)" > index.js
-RUN curl -fsS https://dotenvx.sh | sh
+RUN curl -fsS https://dotenvx.sh/install.sh | sh
 CMD ["/usr/local/bin/dotenvx", "run", "--", "echo", "Hello $HELLO"]
 ```
 


### PR DESCRIPTION
Not all Docker images come with a shell. Notably, Scratch and Distroless come without a shell to reduce the image size and harden the image. If you don't have a shell, it can't be exploited.

The easiest solution is to simply copy the binaries for the official image. Since buildx will create an image for each architecture, we don't need an architecture-specific command.

Additionally, it's best to use fully resolved entry point paths just in case someone changes the $PATH variable.

Close #713