### PR TITLE
fix: strip surrounding quotes from env vars on Windows

### DIFF
--- a/src/lib/helpers/smartDotenvPrivateKey.js
+++ b/src/lib/helpers/smartDotenvPrivateKey.js
@@ -7,13 +7,19 @@ const PRIVATE_KEY_SCHEMA = 'DOTENV_PRIVATE_KEY'
 const dotenvParse = require('./dotenvParse')
 const guessPrivateKeyName = require('./guessPrivateKeyName')
 
-function searchProcessEnv (privateKeyName) {
+// Strip surrounding quotes from a value (handles Windows env var edge case where quotes become part of value)
+function stripSurroundingQuotes(value) {
+  if (!value) return value
+  return value.replace(/^(["'`])(.*)\1$/, '$2')
+}
+
+function searchProcessEnv(privateKeyName) {
   if (process.env[privateKeyName] && process.env[privateKeyName].length > 0) {
-    return process.env[privateKeyName]
+    return stripSurroundingQuotes(process.env[privateKeyName])
   }
 }
 
-function searchKeysFile (privateKeyName, envFilepath, envKeysFilepath = null) {
+function searchKeysFile(privateKeyName, envFilepath, envKeysFilepath = null) {
   let keysFilepath = path.resolve(path.dirname(envFilepath), '.env.keys') // typical scenario
   if (envKeysFilepath) { // user specified -fk flag
     keysFilepath = path.resolve(envKeysFilepath)
@@ -29,7 +35,7 @@ function searchKeysFile (privateKeyName, envFilepath, envKeysFilepath = null) {
   }
 }
 
-function invertForPrivateKeyName (envFilepath) {
+function invertForPrivateKeyName(envFilepath) {
   if (!fsx.existsSync(envFilepath)) {
     return null
   }
@@ -51,7 +57,7 @@ function invertForPrivateKeyName (envFilepath) {
   return null
 }
 
-function smartDotenvPrivateKey (envFilepath, envKeysFilepath = null) {
+function smartDotenvPrivateKey(envFilepath, envKeysFilepath = null) {
   let privateKey = null
   let privateKeyName = guessPrivateKeyName(envFilepath) // DOTENV_PRIVATE_KEY_${ENVIRONMENT}
 

--- a/src/lib/helpers/smartDotenvPublicKey.js
+++ b/src/lib/helpers/smartDotenvPublicKey.js
@@ -3,13 +3,19 @@ const dotenvParse = require('./dotenvParse')
 
 const guessPublicKeyName = require('./guessPublicKeyName')
 
-function searchProcessEnv (publicKeyName) {
+// Strip surrounding quotes from a value (handles Windows env var edge case where quotes become part of value)
+function stripSurroundingQuotes(value) {
+  if (!value) return value
+  return value.replace(/^(["'`])(.*)\1$/, '$2')
+}
+
+function searchProcessEnv(publicKeyName) {
   if (process.env[publicKeyName] && process.env[publicKeyName].length > 0) {
-    return process.env[publicKeyName]
+    return stripSurroundingQuotes(process.env[publicKeyName])
   }
 }
 
-function searchEnvFile (publicKeyName, envFilepath) {
+function searchEnvFile(publicKeyName, envFilepath) {
   if (fsx.existsSync(envFilepath)) {
     const keysSrc = fsx.readFileX(envFilepath)
     const keysParsed = dotenvParse(keysSrc)
@@ -20,7 +26,7 @@ function searchEnvFile (publicKeyName, envFilepath) {
   }
 }
 
-function smartDotenvPublicKey (envFilepath) {
+function smartDotenvPublicKey(envFilepath) {
   let publicKey = null
   const publicKeyName = guessPublicKeyName(envFilepath) // DOTENV_PUBLIC_KEY_${ENVIRONMENT}
 


### PR DESCRIPTION
## Summary

On Windows, when encrypting files like `.env.local`, the `dotenvx encrypt` command fails with:

```
Input string must contain hex characters in even length
```

or:

```
hex string expected, got non-hex character
```

This happens because environment variables set with quotes on Windows (e.g., `DOTENV_PUBLIC_KEY_LOCAL="value"`) include the quotes as part of the actual value. When this quoted value is passed to the eciesjs encrypt function, it fails because quote characters are not valid hex.

## Changes

Added a `stripSurroundingQuotes()` helper function to both `smartDotenvPublicKey.js` and `smartDotenvPrivateKey.js` that removes surrounding quotes from values read from `process.env`.

## Testing

Tested locally on Windows with `.env.local` file - encryption now works when env vars have surrounding quotes.

Fixes https://github.com/dotenvx/dotenvx/issues/724
