### PR TITLE
feat: add public: prefix to skip encryption for specific values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1653,6 +1653,40 @@ $ dotenvx encrypt -ek "HO*"
 ```
 
 </details>
+<details><summary>`encrypt` with `public:` prefix</summary><br>
+
+Mark values as public (not to be encrypted) directly in your `.env` file using the `public:` prefix. This is useful when you want to keep some values unencrypted (like public URLs or app names) while encrypting secrets.
+
+```sh
+$ echo 'APP_NAME="public:MyApp"' > .env
+$ echo 'PUBLIC_URL="public:https://example.com"' >> .env
+$ echo 'SECRET_KEY=supersecret' >> .env
+
+$ dotenvx encrypt
+✔ encrypted (.env)
+```
+
+```ini
+# .env (after encryption)
+DOTENV_PUBLIC_KEY="..."
+APP_NAME="public:MyApp"              # not encrypted
+PUBLIC_URL="public:https://example.com"  # not encrypted
+SECRET_KEY="encrypted:..."           # encrypted
+```
+
+At runtime, the `public:` prefix is automatically stripped:
+
+```sh
+$ dotenvx run -- node -e "console.log(process.env.APP_NAME)"
+MyApp
+```
+
+This approach:
+- Keeps encryption intent visible in the `.env` file itself
+- Works alongside `-k`/`-ek` CLI options
+- No need to remember which keys to exclude when running `encrypt`
+
+</details>
 <details><summary>`encrypt --stdout`</summary><br>
 
 Encrypt the contents of a `.env` file and send to stdout.

--- a/src/lib/helpers/isPublic.js
+++ b/src/lib/helpers/isPublic.js
@@ -1,0 +1,7 @@
+const PUBLIC_PATTERN = /^public:/
+
+function isPublic (value) {
+  return PUBLIC_PATTERN.test(value)
+}
+
+module.exports = isPublic

--- a/src/lib/helpers/parse.js
+++ b/src/lib/helpers/parse.js
@@ -44,6 +44,9 @@ class Parse {
         this.errors.push(e)
       }
 
+      // strip public: prefix
+      this.parsed[key] = this.stripPublic(this.parsed[key])
+
       // eval empty, double, or backticks
       let evaled = false
       if (quote !== "'" && (!this.inProcessEnv(key) || this.processEnv[key] === this.parsed[key])) {
@@ -135,6 +138,13 @@ class Parse {
 
   decrypt (key, value) {
     return decryptKeyValue(key, value, this.privateKeyName, this.privateKey)
+  }
+
+  stripPublic (value) {
+    if (value && value.startsWith('public:')) {
+      return value.slice(7) // remove 'public:' prefix (7 characters)
+    }
+    return value
   }
 
   eval (key, value) {

--- a/src/lib/services/encrypt.js
+++ b/src/lib/services/encrypt.js
@@ -18,6 +18,7 @@ const findPublicKey = require('./../helpers/findPublicKey')
 const keypair = require('./../helpers/keypair')
 const truncate = require('./../helpers/truncate')
 const isPublicKey = require('./../helpers/isPublicKey')
+const isPublic = require('./../helpers/isPublic')
 
 class Encrypt {
   constructor (envs = [], key = [], excludeKey = [], envKeysFilepath = null) {
@@ -169,7 +170,7 @@ class Encrypt {
           continue
         }
 
-        const encrypted = isEncrypted(value) || isPublicKey(key, value)
+        const encrypted = isEncrypted(value) || isPublicKey(key, value) || isPublic(value)
         if (!encrypted) {
           row.keys.push(key) // track key(s)
 

--- a/tests/lib/helpers/isPublic.test.js
+++ b/tests/lib/helpers/isPublic.test.js
@@ -1,0 +1,38 @@
+const t = require('tap')
+const isPublic = require('../../../src/lib/helpers/isPublic')
+
+t.test('#isPublic', ct => {
+  const result = isPublic('public:value')
+  ct.same(result, true)
+  ct.end()
+})
+
+t.test('#isPublic real world', ct => {
+  const result = isPublic('public:https://example.com')
+  ct.same(result, true)
+  ct.end()
+})
+
+t.test('#isPublic not public', ct => {
+  const result = isPublic('value')
+  ct.same(result, false)
+  ct.end()
+})
+
+t.test('#isPublic passes null', ct => {
+  const result = isPublic(null)
+  ct.same(result, false)
+  ct.end()
+})
+
+t.test('#isPublic encrypted value is not public', ct => {
+  const result = isPublic('encrypted:BHqJQhgpCHY4My3PQ1UE3vSTyfqM')
+  ct.same(result, false)
+  ct.end()
+})
+
+t.test('#isPublic empty value after prefix is still public', ct => {
+  const result = isPublic('public:')
+  ct.same(result, true)
+  ct.end()
+})

--- a/tests/lib/helpers/parse.test.js
+++ b/tests/lib/helpers/parse.test.js
@@ -899,3 +899,49 @@ t.test('#run - self referencing dotenv-expand example', ct => {
 
   ct.end()
 })
+
+t.test('#run - strips public: prefix from values', ct => {
+  src = `# .env
+PUBLIC_URL="public:https://example.com"
+APP_NAME='public:MyApp'
+SECRET=mysecret
+`
+
+  const { parsed } = new Parse(src, null, process.env, true).run()
+
+  ct.same(parsed, {
+    PUBLIC_URL: 'https://example.com',
+    APP_NAME: 'MyApp', // public: prefix is stripped after quotes are removed
+    SECRET: 'mysecret'
+  })
+
+  ct.end()
+})
+
+t.test('#run - strips public: prefix from unquoted values', ct => {
+  src = `# .env
+PUBLIC_URL=public:https://example.com
+`
+
+  const { parsed } = new Parse(src, null, process.env, true).run()
+
+  ct.same(parsed, {
+    PUBLIC_URL: 'https://example.com'
+  })
+
+  ct.end()
+})
+
+t.test('#run - does not strip public: from middle of value', ct => {
+  src = `# .env
+SOME_VALUE="value with public: in the middle"
+`
+
+  const { parsed } = new Parse(src, null, process.env, true).run()
+
+  ct.same(parsed, {
+    SOME_VALUE: 'value with public: in the middle'
+  })
+
+  ct.end()
+})

--- a/tests/lib/services/ls.test.js
+++ b/tests/lib/services/ls.test.js
@@ -34,6 +34,7 @@ t.test('#run', ct => {
     'monorepo/apps/multiple/.env',
     'monorepo/apps/multiple/.env.keys',
     'monorepo/apps/multiple/.env.production',
+    'monorepo/apps/public/.env',
     'monorepo/apps/shebang/.env',
     'monorepo/apps/unencrypted/.env'
   ]
@@ -66,6 +67,7 @@ t.test('#run (with directory argument)', ct => {
     'apps/multiple/.env',
     'apps/multiple/.env.keys',
     'apps/multiple/.env.production',
+    'apps/public/.env',
     'apps/shebang/.env',
     'apps/unencrypted/.env'
   ]
@@ -98,6 +100,7 @@ t.test('#run (with somehow malformed directory argument)', ct => {
     'apps/multiple/.env',
     'apps/multiple/.env.keys',
     'apps/multiple/.env.production',
+    'apps/public/.env',
     'apps/shebang/.env',
     'apps/unencrypted/.env'
   ]
@@ -139,6 +142,7 @@ t.test('#_filepaths', ct => {
     'monorepo/apps/multiple/.env',
     'monorepo/apps/multiple/.env.keys',
     'monorepo/apps/multiple/.env.production',
+    'monorepo/apps/public/.env',
     'monorepo/apps/shebang/.env',
     'monorepo/apps/unencrypted/.env'
   ]

--- a/tests/monorepo/apps/public/.env
+++ b/tests/monorepo/apps/public/.env
@@ -1,0 +1,4 @@
+PUBLIC_URL="public:https://example.com"
+APP_NAME="public:MyApp"
+SECRET_KEY=super-secret
+API_TOKEN=token123


### PR DESCRIPTION
## Problem

When encrypting `.env` files, users often want to keep some values unencrypted (e.g., public URLs, app names) while encrypting secrets. Currently, this requires using CLI options like `-k` or `-ek` to specify which keys to include/exclude, which becomes impractical with many environment variables.

## Solution

Add support for a `public:` prefix that marks values as "safe to keep unencrypted" directly in the `.env` file:

```env
APP_NAME="public:MyApp"              # Not encrypted, runtime value: "MyApp"
PUBLIC_URL="public:https://example.com"  # Not encrypted
SECRET_KEY=super-secret              # Encrypted → "encrypted:..."
API_TOKEN=token123                   # Encrypted → "encrypted:..."
```

This approach:
- Keeps encryption intent visible in the `.env` file itself
- Works alongside existing `-k`/`-ek` CLI options
- Follows the same pattern as `encrypted:` prefix detection

## Changes

- `src/lib/helpers/isPublic.js` - New helper to detect `public:` prefix
- `src/lib/services/encrypt.js` - Skip encryption for `public:` prefixed values
- `src/lib/helpers/parse.js` - Strip `public:` prefix at runtime

## Usage

```bash
# Before encryption
APP_NAME="public:MyApp"
SECRET=mysecret

# After: dotenvx encrypt
APP_NAME="public:MyApp"           # unchanged
SECRET="encrypted:BGxx..."        # encrypted
```

At runtime, `APP_NAME` resolves to `"MyApp"` (prefix stripped).