### PR TITLE
Proposal: Allow to set DOTENV_CONVENTION as environment variable

### DIFF
--- a/src/cli/actions/run.js
+++ b/src/cli/actions/run.js
@@ -15,6 +15,7 @@ async function run () {
 
   const options = this.opts()
   logger.debug(`options: ${JSON.stringify(options)}`)
+  const convention = options.convention || process.env.DOTENV_CONVENTION
 
   const ignore = options.ignore || []
 
@@ -37,8 +38,8 @@ async function run () {
   try {
     let envs = []
     // handle shorthand conventions - like --convention=nextjs
-    if (options.convention) {
-      envs = conventions(options.convention).concat(this.envs)
+    if (convention) {
+      envs = conventions(convention).concat(this.envs)
     } else {
       envs = this.envs
     }
@@ -82,7 +83,7 @@ async function run () {
         if (options.strict) throw error // throw if strict and not ignored
 
         if (error.code === 'MISSING_ENV_FILE') {
-          if (!options.convention) { // do not output error for conventions (too noisy)
+          if (!convention) { // do not output error for conventions (too noisy)
             logger.error(error.message)
             if (error.help) {
               logger.error(`${error.help} and re-run [dotenvx run -- ${commandArgs.join(' ')}]`)

--- a/tests/cli/actions/run.test.js
+++ b/tests/cli/actions/run.test.js
@@ -11,6 +11,12 @@ const { logger } = require('../../../src/shared/logger')
 const run = proxyquire('../../../src/cli/actions/run', {
   '../../../src/lib/helpers/executeCommand': async () => true
 })
+const runWithConventionStub = function (conventionsStub) {
+  return proxyquire('../../../src/cli/actions/run', {
+    '../../../src/lib/helpers/executeCommand': async () => true,
+    '../../../src/lib/helpers/conventions': conventionsStub
+  })
+}
 
 t.beforeEach((ct) => {
   sinon.restore()
@@ -76,6 +82,54 @@ t.test('run --convention', async ct => {
 
   t.ok(stub.called, 'new Run().run() called')
   t.ok(loggerSuccessvStub.calledWith('injecting env (0)'), 'logger.successv')
+
+  ct.end()
+})
+
+t.test('run - DOTENV_CONVENTION', async ct => {
+  const conventionsStub = sinon.stub().returns([])
+  const runAction = runWithConventionStub(conventionsStub)
+  const optsStub = sinon.stub().returns({})
+  const fakeContext = { opts: optsStub, args: ['echo', ''], envs: [] }
+  process.env.DOTENV_CONVENTION = 'flow'
+  sinon.stub(process, 'argv').value(['node', 'dotenvx', 'run', '--', 'echo', ''])
+  const stub = sinon.stub(Run.prototype, 'run')
+  stub.returns({
+    processedEnvs: [],
+    readableStrings: [],
+    readableFilepaths: [],
+    uniqueInjectedKeys: []
+  })
+  const loggerSuccessvStub = sinon.stub(logger, 'successv')
+
+  await runAction.call(fakeContext)
+
+  t.ok(conventionsStub.calledWith('flow'), 'uses DOTENV_CONVENTION')
+  t.ok(stub.called, 'new Run().run() called')
+  t.ok(loggerSuccessvStub.calledWith('injecting env (0)'), 'logger.successv')
+
+  ct.end()
+})
+
+t.test('run --convention takes precedence over DOTENV_CONVENTION', async ct => {
+  const conventionsStub = sinon.stub().returns([])
+  const runAction = runWithConventionStub(conventionsStub)
+  const optsStub = sinon.stub().returns({ convention: 'nextjs' })
+  const fakeContext = { opts: optsStub, args: ['echo', ''], envs: [] }
+  process.env.DOTENV_CONVENTION = 'flow'
+  sinon.stub(process, 'argv').value(['node', 'dotenvx', 'run', '--', 'echo', ''])
+  const stub = sinon.stub(Run.prototype, 'run')
+  stub.returns({
+    processedEnvs: [],
+    readableStrings: [],
+    readableFilepaths: [],
+    uniqueInjectedKeys: []
+  })
+
+  await runAction.call(fakeContext)
+
+  t.ok(conventionsStub.calledWith('nextjs'), 'uses --convention when both are set')
+  t.ok(stub.called, 'new Run().run() called')
 
   ct.end()
 })
@@ -449,6 +503,38 @@ t.test('run - MISSING_ENV_FILE', async ct => {
   t.ok(loggerErrorStub.calledWith('Mock Error'), 'logger.error')
   t.ok(loggerErrorStub.calledWith('[MISSING_ENV_FILE] ? add one with [echo "HELLO=World" > .env] and re-run [dotenvx run -- echo ]'), 'logger.help')
   t.ok(loggerSuccessvStub.calledWith('injecting env (0)'), 'logger.successv')
+
+  ct.end()
+})
+
+t.test('run - MISSING_ENV_FILE with DOTENV_CONVENTION is silent', async ct => {
+  const error = new Error('Mock Error')
+  error.code = 'MISSING_ENV_FILE'
+  error.help = '[MISSING_ENV_FILE] ? add one with [echo "HELLO=World" > .env]'
+  const optsStub = sinon.stub().returns({})
+  const fakeContext = { opts: optsStub, args: ['echo', ''], envs: [] }
+  process.env.DOTENV_CONVENTION = 'nextjs'
+  sinon.stub(process, 'argv').value(['node', 'dotenvx', 'run', '--', 'echo', ''])
+  const stub = sinon.stub(Run.prototype, 'run')
+  stub.returns({
+    processedEnvs: [{
+      errors: [error],
+      type: 'envFile',
+      filepath: '.env',
+      parsed: {},
+      injected: {},
+      preExisted: {}
+    }],
+    readableStrings: [],
+    readableFilepaths: [],
+    uniqueInjectedKeys: []
+  })
+  const loggerErrorStub = sinon.stub(logger, 'error')
+
+  await run.call(fakeContext)
+
+  t.ok(stub.called, 'new Run().run() called')
+  t.notOk(loggerErrorStub.called, 'logger.error')
 
   ct.end()
 })


### PR DESCRIPTION
I keep littering my `package.json`'s `scripts` with `dotenv run --convention=flow`. I think it would be tremendously practical to be able to set this globally as an environment variable, while still allowing to override it as needed (e.g. if one specific case uses `nextjs`, while others use `flow`).

This PR adds that possibility.