### PR TITLE
Add --exclude option to precommit and prebuild commands

### DIFF
--- a/src/cli/commands/ext.js
+++ b/src/cli/commands/ext.js
@@ -45,6 +45,7 @@ ext.command('prebuild')
   .description('prevent including .env files in docker builds')
   .addHelpText('after', examples.prebuild)
   .argument('[directory]', 'directory to prevent including .env files from', '.')
+  .option('-x, --exclude <patterns...>', 'pattern(s) to exclude from .env file checks')
   .action(require('./../actions/ext/prebuild'))
 
 // dotenvx ext precommit
@@ -53,6 +54,7 @@ ext.command('precommit')
   .addHelpText('after', examples.precommit)
   .argument('[directory]', 'directory to prevent committing .env files from', '.')
   .option('-i, --install', 'install to .git/hooks/pre-commit')
+  .option('-x, --exclude <patterns...>', 'pattern(s) to exclude from .env file checks')
   .action(require('./../actions/ext/precommit'))
 
 // dotenvx scan

--- a/src/lib/services/prebuild.js
+++ b/src/lib/services/prebuild.js
@@ -10,11 +10,13 @@ const packageJson = require('./../helpers/packageJson')
 const MISSING_DOCKERIGNORE = '.env.keys' // by default only ignore .env.keys. all other .env* files COULD be included - as long as they are encrypted
 
 class Prebuild {
-  constructor (directory = './') {
+  constructor (directory = './', options = {}) {
     // args
     this.directory = directory
 
-    this.excludeEnvFile = ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**']
+    const defaultExclusions = ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**']
+    const userExclusions = options.exclude || []
+    this.excludeEnvFile = defaultExclusions.concat(userExclusions)
   }
 
   run () {

--- a/src/lib/services/precommit.js
+++ b/src/lib/services/precommit.js
@@ -17,7 +17,10 @@ class Precommit {
     this.directory = directory
     // options
     this.install = options.install
-    this.excludeEnvFile = ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**']
+
+    const defaultExclusions = ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**']
+    const userExclusions = options.exclude || []
+    this.excludeEnvFile = defaultExclusions.concat(userExclusions)
   }
 
   run () {

--- a/tests/lib/services/prebuild.test.js
+++ b/tests/lib/services/prebuild.test.js
@@ -161,3 +161,33 @@ t.test('#run (.env files in subfolders throw error in prebuild hook)', ct => {
 
   ct.end()
 })
+
+t.test('#constructor sets default exclusions', ct => {
+  const prebuild = new Prebuild()
+
+  ct.same(prebuild.excludeEnvFile, ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**'])
+
+  ct.end()
+})
+
+t.test('#constructor merges user exclusions with defaults', ct => {
+  const prebuild = new Prebuild('./', { exclude: ['.env.*.config', '.env.public'] })
+
+  ct.same(prebuild.excludeEnvFile, ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**', '.env.*.config', '.env.public'])
+
+  ct.end()
+})
+
+t.test('#run passes exclusions to Ls service', ct => {
+  sinon.stub(fsx, 'existsSync').returns(true)
+  sinon.stub(fsx, 'readFileX').returns('')
+  const lsRunStub = sinon.stub(Ls.prototype, 'run').returns([])
+
+  const prebuild = new Prebuild('./', { exclude: ['.env.custom'] })
+  prebuild.run()
+
+  ct.ok(lsRunStub.called, 'Ls.run should be called')
+  ct.same(prebuild.excludeEnvFile, ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**', '.env.custom'])
+
+  ct.end()
+})

--- a/tests/lib/services/precommit.test.js
+++ b/tests/lib/services/precommit.test.js
@@ -209,3 +209,31 @@ t.test('_installPrecommitHook calls InstallPrecommitHook.run', ct => {
 
   ct.end()
 })
+
+t.test('#constructor sets default exclusions', ct => {
+  const precommit = new Precommit()
+
+  ct.same(precommit.excludeEnvFile, ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**'])
+
+  ct.end()
+})
+
+t.test('#constructor merges user exclusions with defaults', ct => {
+  const precommit = new Precommit('./', { exclude: ['.env.*.config', '.env.public'] })
+
+  ct.same(precommit.excludeEnvFile, ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**', '.env.*.config', '.env.public'])
+
+  ct.end()
+})
+
+t.test('#run passes exclusions to Ls service', ct => {
+  const lsRunStub = sinon.stub(Ls.prototype, 'run').returns([])
+
+  const precommit = new Precommit('./', { exclude: ['.env.custom'] })
+  precommit.run()
+
+  ct.ok(lsRunStub.called, 'Ls.run should be called')
+  ct.same(precommit.excludeEnvFile, ['test/**', 'tests/**', 'spec/**', 'specs/**', 'pytest/**', 'test_suite/**', '.env.custom'])
+
+  ct.end()
+})


### PR DESCRIPTION
## Summary

This commit adds:
- `-x`, `--exclude <patterns...>` CLI option to both ext precommit and ext prebuild commands
- User-provided exclusion patterns are merged with the default test directory exclusions
- Tests for the new functionality

## Motivation
Not all environment variables are secrets. Configuration values like feature flags, API endpoints, and log levels often live alongside sensitive credentials.

When all `.env` files must be encrypted, reviewers without decryption keys cannot verify configuration changes, which effectively bypasses the four-eyes principle. A compromised developer could inject malicious configuration (e.g., redirecting API calls or enabling insecure debugging features) that no one can audit.

The `--exclude` option enables teams to separate secrets from configuration: encrypt only `.env.*.secret` files while keeping `.env.*.config` files reviewable.

## Usage
`dotenvx ext precommit -x '.env.*.config' -x '.env.*.public'`
`dotenvx ext prebuild -x '.env.*.config' -x '.env.*.public'`