### PR TITLE
fix: correct default value interpolation for empty strings

### DIFF
--- a/src/lib/helpers/parse.js
+++ b/src/lib/helpers/parse.js
@@ -164,23 +164,33 @@ class Parse {
 
       const r = expression.split(splitter)
 
-      let defaultValue
-      let value
+      let replacementValue
       const key = r.shift()
+      const rest = r.join(splitter)
 
-      if ([':+', '+'].includes(splitter)) {
-        defaultValue = env[key] ? r.join(splitter) : ''
-        value = null
+      // Handle operators:
+      // :- use default if unset OR empty
+      // - use default only if unset (empty is valid)
+      // :+ use alternate if set AND non-empty, otherwise empty
+      // + use alternate if set (even if empty), otherwise empty
+      if (splitter === ':-') {
+        // Use default if unset or empty
+        replacementValue = env[key] || rest
+      } else if (splitter === '-') {
+        // Use default only if unset (check if key exists in env)
+        replacementValue = (key in env) ? env[key] : rest
+      } else if (splitter === ':+') {
+        // Use alternate only if set AND non-empty
+        replacementValue = env[key] ? rest : ''
+      } else if (splitter === '+') {
+        // Use alternate if set (even if empty)
+        replacementValue = (key in env) ? rest : ''
       } else {
-        defaultValue = r.join(splitter)
-        value = env[key]
+        // No operator - simple expansion
+        replacementValue = env[key] || ''
       }
 
-      if (value) {
-        result = result.replace(template, value)
-      } else {
-        result = result.replace(template, defaultValue)
-      }
+      result = result.replace(template, replacementValue)
 
       // if the result equaled what was in env then stop expanding - handle self-referential check as well
       if (result === env[key]) {


### PR DESCRIPTION
Fixes #765

## Problem

The interpolation logic for default and alternate values was not correctly handling the difference between unset variables and empty string values.

Per the documentation at https://dotenvx.com/docs/env-file#interpolation:
- `${VAR:-default}` → value of VAR if set and non-empty, otherwise default
- `${VAR-default}` → value of VAR if set, otherwise default

However, previously both syntaxes behaved the same way - they would both use the default when VAR was set to an empty string.

## Solution

Refactored the `expand()` function to correctly handle each operator according to POSIX shell semantics:

| Syntax | Behavior |
|--------|----------|
| `${VAR:-default}` | Uses default if VAR is unset OR empty |
| `${VAR-default}` | Uses default only if VAR is unset (empty is valid) |
| `${VAR:+alternate}` | Uses alternate if VAR is set AND non-empty |
| `${VAR+alternate}` | Uses alternate if VAR is set (empty counts as set) |

## Testing

Tested with the reproduction case from #765:

```bash
# .env.test
EMPTY_VAR=
TEST_COLON="${EMPTY_VAR:-fallback}"  # Results in: fallback
TEST_HYPHEN="${EMPTY_VAR-fallback}" # Results in: "" (empty string)
```

All existing tests continue to pass.
