### PR TITLE
Upgrade picomatch to resolve two vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fdir": "^6.2.0",
     "ignore": "^5.3.0",
     "object-treeify": "1.1.33",
-    "picomatch": "^4.0.2",
+    "picomatch": "^4.0.4",
     "which": "^4.0.0",
     "yocto-spinner": "^1.1.0"
   },


### PR DESCRIPTION
Upgrading picomatch to v4.0.4 resolves these two vulnerabilities:

High - [Regular Expression Denial of Service](https://security.snyk.io/vuln/SNYK-JS-PICOMATCH-15765511)

Medium - [Prototype Pollution](https://security.snyk.io/vuln/SNYK-JS-PICOMATCH-15765513)