### PR TITLE
feat: add --format eval-singlequotes and --format eval-export

### DIFF
--- a/src/cli/actions/get.js
+++ b/src/cli/actions/get.js
@@ -60,10 +60,11 @@ async function get (key) {
         inline = inline.trim()
 
         console.log(inline)
-      } else if (options.format === 'eval-singlequotes') {
+      } else if (options.format === 'eval-singlequotes' || options.format === 'eval-export') {
+        const prefix = options.format === 'eval-export' ? 'export ' : ''
         let inline = ''
         for (const [key, value] of Object.entries(parsed)) {
-          inline += `${key}=${escapeSingleQuote(value)}\n`
+          inline += `${prefix}${key}=${escapeSingleQuote(value)}\n`
         }
         inline = inline.trim()
 

--- a/src/cli/actions/get.js
+++ b/src/cli/actions/get.js
@@ -2,6 +2,7 @@ const { logger } = require('./../../shared/logger')
 
 const conventions = require('./../../lib/helpers/conventions')
 const escape = require('./../../lib/helpers/escape')
+const escapeSingleQuote = require('./../../lib/helpers/escapeSingleQuote')
 const catchAndLog = require('./../../lib/helpers/catchAndLog')
 const createSpinner = require('../../lib/helpers/createSpinner')
 const Session = require('../../db/session')
@@ -55,6 +56,14 @@ async function get (key) {
         let inline = ''
         for (const [key, value] of Object.entries(parsed)) {
           inline += `${key}=${escape(value)}\n`
+        }
+        inline = inline.trim()
+
+        console.log(inline)
+      } else if (options.format === 'eval-singlequotes') {
+        let inline = ''
+        for (const [key, value] of Object.entries(parsed)) {
+          inline += `${key}=${escapeSingleQuote(value)}\n`
         }
         inline = inline.trim()
 

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -92,7 +92,7 @@ program.command('get')
   .option('-a, --all', 'include all machine envs as well')
   .option('-pp, --pretty-print', 'pretty print output')
   .option('--pp', 'pretty print output (alias)')
-  .option('--format <type>', 'format of the output (json, shell, eval)', 'json')
+  .option('--format <type>', 'format of the output (json, shell, eval, eval-singlequotes)', 'json')
   .option('--no-ops', 'disable dotenvx-ops features')
   .action(function (...args) {
     this.envs = envs

--- a/src/cli/dotenvx.js
+++ b/src/cli/dotenvx.js
@@ -92,7 +92,7 @@ program.command('get')
   .option('-a, --all', 'include all machine envs as well')
   .option('-pp, --pretty-print', 'pretty print output')
   .option('--pp', 'pretty print output (alias)')
-  .option('--format <type>', 'format of the output (json, shell, eval, eval-singlequotes)', 'json')
+  .option('--format <type>', 'format of the output (json, shell, eval, eval-singlequotes, eval-export)', 'json')
   .option('--no-ops', 'disable dotenvx-ops features')
   .action(function (...args) {
     this.envs = envs

--- a/src/lib/helpers/escapeSingleQuote.js
+++ b/src/lib/helpers/escapeSingleQuote.js
@@ -1,0 +1,8 @@
+function escapeSingleQuote (value) {
+  // Wrap value in single quotes for shell-safe eval.
+  // Any embedded single quotes are escaped using the POSIX idiom: '\''
+  // (end single-quoted string, insert escaped literal quote, re-open single-quoted string)
+  return "'" + value.replace(/'/g, "'\\''") + "'"
+}
+
+module.exports = escapeSingleQuote

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -19,6 +19,7 @@ const buildEnvs = require('./helpers/buildEnvs')
 const Parse = require('./helpers/parse')
 const fsx = require('./helpers/fsx')
 const localDisplayPath = require('./helpers/localDisplayPath')
+const escapeSingleQuote = require('./helpers/escapeSingleQuote')
 
 /** @type {import('./main').config} */
 const config = function (options = {}) {
@@ -261,6 +262,14 @@ const get = function (key, options = {}) {
       let inline = ''
       for (const [key, value] of Object.entries(parsed)) {
         inline += `${key}=${escape(value)}\n`
+      }
+      inline = inline.trim()
+
+      return inline
+    } else if (options.format === 'eval-singlequotes') {
+      let inline = ''
+      for (const [key, value] of Object.entries(parsed)) {
+        inline += `${key}=${escapeSingleQuote(value)}\n`
       }
       inline = inline.trim()
 

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -266,10 +266,11 @@ const get = function (key, options = {}) {
       inline = inline.trim()
 
       return inline
-    } else if (options.format === 'eval-singlequotes') {
+    } else if (options.format === 'eval-singlequotes' || options.format === 'eval-export') {
+      const prefix = options.format === 'eval-export' ? 'export ' : ''
       let inline = ''
       for (const [key, value] of Object.entries(parsed)) {
-        inline += `${key}=${escapeSingleQuote(value)}\n`
+        inline += `${prefix}${key}=${escapeSingleQuote(value)}\n`
       }
       inline = inline.trim()
 

--- a/tests/cli/actions/get.test.js
+++ b/tests/cli/actions/get.test.js
@@ -249,6 +249,86 @@ t.test('get --format eval-singlequotes (multiple keys use newlines)', async ct =
   ct.end()
 })
 
+t.test('get --format eval-export (basic)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-export' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { HELLO: 'World' } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "export HELLO='World'\n")
+
+  ct.end()
+})
+
+t.test('get --format eval-export (with dollar sign in value)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-export' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { PASSWORD: 'price$100' } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "export PASSWORD='price$100'\n")
+
+  ct.end()
+})
+
+t.test('get --format eval-export (with backtick in value)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-export' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { PASSWORD: 'foo`bar' } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "export PASSWORD='foo`bar'\n")
+
+  ct.end()
+})
+
+t.test('get --format eval-export (with single quotes in value)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-export' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { HELLO: "f'bar" } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "export HELLO='f'\\''bar'\n")
+
+  ct.end()
+})
+
+t.test('get --format eval-export (multiple keys use newlines)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-export' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { HELLO: 'World', HELLO2: 'World2' } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "export HELLO='World'\nexport HELLO2='World2'\n")
+
+  ct.end()
+})
+
 t.test('get --pretty-print', async ct => {
   const optsStub = sinon.stub().returns({ prettyPrint: true })
   const fakeContext = { opts: optsStub }

--- a/tests/cli/actions/get.test.js
+++ b/tests/cli/actions/get.test.js
@@ -169,6 +169,86 @@ t.test('get --format eval (multiple keys use newlines)', async ct => {
   ct.end()
 })
 
+t.test('get --format eval-singlequotes (basic)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-singlequotes' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { HELLO: 'World' } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "HELLO='World'\n")
+
+  ct.end()
+})
+
+t.test('get --format eval-singlequotes (with dollar sign in value)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-singlequotes' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { PASSWORD: 'price$100' } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "PASSWORD='price$100'\n")
+
+  ct.end()
+})
+
+t.test('get --format eval-singlequotes (with backtick in value)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-singlequotes' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { PASSWORD: 'foo`bar' } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "PASSWORD='foo`bar'\n")
+
+  ct.end()
+})
+
+t.test('get --format eval-singlequotes (with single quotes in value)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-singlequotes' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { HELLO: "f'bar" } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "HELLO='f'\\''bar'\n")
+
+  ct.end()
+})
+
+t.test('get --format eval-singlequotes (multiple keys use newlines)', async ct => {
+  const optsStub = sinon.stub().returns({ format: 'eval-singlequotes' })
+  const fakeContext = { opts: optsStub }
+  const stub = sinon.stub(Get.prototype, 'run')
+  stub.returns({ parsed: { HELLO: 'World', HELLO2: 'World2' } })
+
+  const stdout = await captureStdout(async () => {
+    await get.call(fakeContext, undefined)
+  })
+
+  t.ok(stub.called, 'Get().run() called')
+  t.equal(stdout, "HELLO='World'\nHELLO2='World2'\n")
+
+  ct.end()
+})
+
 t.test('get --pretty-print', async ct => {
   const optsStub = sinon.stub().returns({ prettyPrint: true })
   const fakeContext = { opts: optsStub }

--- a/tests/lib/main.test.js
+++ b/tests/lib/main.test.js
@@ -1546,6 +1546,51 @@ t.test('get calls Get.runSync format shell',
     ct.end()
   })
 
+t.test('get calls Get.runSync format eval-singlequotes',
+  ct => {
+    const stub = sinon.stub(Get.prototype, 'runSync')
+    stub.returns({ parsed: { KEY: 'value' }, errors: [] })
+
+    const result = main.get(null, { format: 'eval-singlequotes' })
+    t.equal(result, "KEY='value'")
+
+    t.ok(stub.called, 'new Get().runSync() called')
+
+    stub.restore()
+
+    ct.end()
+  })
+
+t.test('get calls Get.runSync format eval-singlequotes with dollar sign',
+  ct => {
+    const stub = sinon.stub(Get.prototype, 'runSync')
+    stub.returns({ parsed: { PASSWORD: 'price$100' }, errors: [] })
+
+    const result = main.get(null, { format: 'eval-singlequotes' })
+    t.equal(result, "PASSWORD='price$100'")
+
+    t.ok(stub.called, 'new Get().runSync() called')
+
+    stub.restore()
+
+    ct.end()
+  })
+
+t.test('get calls Get.runSync format eval-singlequotes with single quote in value',
+  ct => {
+    const stub = sinon.stub(Get.prototype, 'runSync')
+    stub.returns({ parsed: { KEY: "it's" }, errors: [] })
+
+    const result = main.get(null, { format: 'eval-singlequotes' })
+    t.equal(result, "KEY='it'\\''s'")
+
+    t.ok(stub.called, 'new Get().runSync() called')
+
+    stub.restore()
+
+    ct.end()
+  })
+
 t.test('get calls Get.runSync with noOps true',
   ct => {
     const stub = sinon.stub(Get.prototype, 'runSync')

--- a/tests/lib/main.test.js
+++ b/tests/lib/main.test.js
@@ -1591,6 +1591,66 @@ t.test('get calls Get.runSync format eval-singlequotes with single quote in valu
     ct.end()
   })
 
+t.test('get calls Get.runSync format eval-export',
+  ct => {
+    const stub = sinon.stub(Get.prototype, 'runSync')
+    stub.returns({ parsed: { KEY: 'value' }, errors: [] })
+
+    const result = main.get(null, { format: 'eval-export' })
+    t.equal(result, "export KEY='value'")
+
+    t.ok(stub.called, 'new Get().runSync() called')
+
+    stub.restore()
+
+    ct.end()
+  })
+
+t.test('get calls Get.runSync format eval-export with dollar sign',
+  ct => {
+    const stub = sinon.stub(Get.prototype, 'runSync')
+    stub.returns({ parsed: { PASSWORD: 'price$100' }, errors: [] })
+
+    const result = main.get(null, { format: 'eval-export' })
+    t.equal(result, "export PASSWORD='price$100'")
+
+    t.ok(stub.called, 'new Get().runSync() called')
+
+    stub.restore()
+
+    ct.end()
+  })
+
+t.test('get calls Get.runSync format eval-export with single quote in value',
+  ct => {
+    const stub = sinon.stub(Get.prototype, 'runSync')
+    stub.returns({ parsed: { KEY: "it's" }, errors: [] })
+
+    const result = main.get(null, { format: 'eval-export' })
+    t.equal(result, "export KEY='it'\\''s'")
+
+    t.ok(stub.called, 'new Get().runSync() called')
+
+    stub.restore()
+
+    ct.end()
+  })
+
+t.test('get calls Get.runSync format eval-export with multiple keys',
+  ct => {
+    const stub = sinon.stub(Get.prototype, 'runSync')
+    stub.returns({ parsed: { KEY1: 'val1', KEY2: 'val2' }, errors: [] })
+
+    const result = main.get(null, { format: 'eval-export' })
+    t.equal(result, "export KEY1='val1'\nexport KEY2='val2'")
+
+    t.ok(stub.called, 'new Get().runSync() called')
+
+    stub.restore()
+
+    ct.end()
+  })
+
 t.test('get calls Get.runSync with noOps true',
   ct => {
     const stub = sinon.stub(Get.prototype, 'runSync')


### PR DESCRIPTION
## Summary

Fixes #783

`--format eval` wraps values in double quotes, which causes the shell to interpret `$` and backticks inside values — silently corrupting passwords, connection strings, and other values containing these characters.

This PR adds two new format options that use single quotes (POSIX literal quoting) to prevent shell expansion:

- **`--format eval-singlequotes`** — same as `--format eval` but wraps values in single quotes. Embedded single quotes are escaped using the standard POSIX idiom (`'\''`).
- **`--format eval-export`** — single-quoted values prefixed with `export`, ready for `eval "$(dotenvx get --format eval-export)"`.

### Example

```sh
# Before (broken with special chars):
> dotenvx get -f .env --format eval
PASSWORD="foo$bar"

# New single-quote format:
> dotenvx get -f .env --format eval-singlequotes
PASSWORD='foo$bar'

# New export format:
> dotenvx get -f .env --format eval-export
export PASSWORD='foo$bar'
```

### Changes

- `src/cli/actions/get.js` — handle `eval-singlequotes` and `eval-export` format options
- `src/cli/dotenvx.js` — update `--format` help text to list new options
- `src/lib/helpers/escapeSingleQuote.js` — new helper to escape embedded single quotes
- `src/lib/main.js` — add format logic in the main lib
- `tests/cli/actions/get.test.js` — test coverage for both new formats
- `tests/lib/main.test.js` — test coverage for both new formats