### PR TITLE
chore: missing linux-aarch64 from unversioned file released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,7 @@ jobs:
           tar --gzip -cf ./dist/dotenvx-linux-amd64.tar.gz -C bin/linux-amd64/ .
           tar --gzip -cf ./dist/dotenvx-linux-x86_64.tar.gz -C bin/linux-x86_64/ .
           tar --gzip -cf ./dist/dotenvx-linux-arm64.tar.gz -C bin/linux-arm64/ .
+          tar --gzip -cf ./dist/dotenvx-linux-aarch64.tar.gz -C bin/linux-aarch64/ .
           tar --gzip -cf ./dist/dotenvx-linux-armv7l.tar.gz -C bin/linux-armv7l/ .
           tar --gzip -cf ./dist/dotenvx-windows-amd64.tar.gz -C bin/windows-amd64/ .
           tar --gzip -cf ./dist/dotenvx-windows-x86_64.tar.gz -C bin/windows-x86_64/ .


### PR DESCRIPTION
Hi, I noticed that the unversioned package file in the release for linux-aarch64 is not available, even though the versioned file is available.

This made my docker file setup broken: `RUN curl -L -o dotenvx.tar.gz "https://github.com/dotenvx/dotenvx/releases/latest/download/dotenvx-$(uname -s)-$(uname -m).tar.gz"`

<img width="868" height="752" alt="image" src="https://github.com/user-attachments/assets/3a58ce6b-4c69-45e1-adda-e02a258f2ffe" />

I noticed that linux-aarch64 line is missing in the workflow. 