### PR TITLE
fix(parse): unescape escaped single quotes in single-quoted values

### DIFF
--- a/src/lib/helpers/parse.js
+++ b/src/lib/helpers/parse.js
@@ -123,6 +123,10 @@ class Parse {
     // Remove surrounding quotes
     v = v.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
 
+    if (_quote === "'") {
+      v = v.replace(/\\'/g, "'")
+    }
+
     // Expand newlines if double quoted
     if (_quote === '"') {
       v = v.replace(/\\n/g, '\n') // newline

--- a/tests/lib/helpers/parse.test.js
+++ b/tests/lib/helpers/parse.test.js
@@ -817,6 +817,20 @@ TABS_SINGLE='hi\\tfriend'
   ct.end()
 })
 
+t.test('#run - unescape escaped single quotes in single quoted values - https://github.com/dotenvx/dotenvx/issues/728', ct => {
+  src = `# .env
+QUOTE='Let\\'s go!'
+`
+
+  const { parsed } = new Parse(src, null, process.env, true).run()
+
+  ct.same(parsed, {
+    QUOTE: "Let's go!"
+  })
+
+  ct.end()
+})
+
 t.test('#run - combine complex expansion and evaluation from same .env file - https://github.com/dotenvx/dotenvx/issues/488', ct => {
   src = `# .env
 FILENAME=$(echo tests/monorepo/apps/unencrypted/.env)


### PR DESCRIPTION
Fixes #728

A value like `VAR='Let\\'s go!'` currently keeps the escape backslash when it is parsed, so `dotenvx get VAR` returns `Let\\'s go!` instead of `Let's go!`.\n\nThis unescapes `\\'` after removing the surrounding single quotes and adds a regression test for that parser case.\n\nValidation:\n- `npm test`