### PR TITLE
Add support DOTENV_CONFIG_IGNORE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1586,6 +1586,11 @@ $ dotenvx run -f .env.missing --ignore=MISSING_ENV_FILE -- node index.js
 ...
 ```
 
+You can also set `DOTENV_CONFIG_IGNORE="MISSING_ENV_FILE"`. It is parsed as a comma-separated list.
+
+```sh
+$ DOTENV_CONFIG_IGNORE="MISSING_ENV_FILE,OTHER_ERROR_CODE" dotenvx run -f .env.missing -- node index.js
+```
 </details>
 <details><summary>`run --convention=nextjs`</summary><br>
 

--- a/src/lib/helpers/normalizeDotenvConfigConvention.js
+++ b/src/lib/helpers/normalizeDotenvConfigConvention.js
@@ -1,4 +1,6 @@
-function normalizeDotenvConfigConvention (options) {
+function normalizeDotenvConfigConvention(
+  /** @type {import('../main').DotenvConfigOptions} */ options
+) {
   if (!options.convention && process.env.DOTENV_CONFIG_CONVENTION) {
     options.convention = process.env.DOTENV_CONFIG_CONVENTION
   }

--- a/src/lib/helpers/normalizeDotenvConfigIgnore.js
+++ b/src/lib/helpers/normalizeDotenvConfigIgnore.js
@@ -1,0 +1,13 @@
+function normalizeDotenvConfigIgnore(
+  /** @type {import('../main').DotenvConfigOptions} */ options
+) {
+  if (process.env.DOTENV_CONFIG_IGNORE) {
+    const ignoreVariables = (process.env.DOTENV_CONFIG_IGNORE).split(',');
+    options.ignore ??= []; // Retain ignore from explicit arguments
+    options.ignore.push(...ignoreVariables)
+  }
+
+  return options
+}
+
+module.exports = normalizeDotenvConfigIgnore

--- a/src/lib/helpers/normalizeDotenvConfigQuiet.js
+++ b/src/lib/helpers/normalizeDotenvConfigQuiet.js
@@ -1,4 +1,6 @@
-function normalizeDotenvConfigQuiet (options) {
+function normalizeDotenvConfigQuiet(
+  /** @type {import('../main').DotenvConfigOptions} */ options
+) {
   if (process.env.DOTENV_CONFIG_QUIET === 'true') {
     options.quiet = true
   }

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -26,6 +26,7 @@ const decryptKeyValue = require('./helpers/cryptography/decryptKeyValue')
 const Errors = require('./helpers/errors')
 const normalizeDotenvConfigQuiet = require('./helpers/normalizeDotenvConfigQuiet')
 const normalizeDotenvConfigConvention = require('./helpers/normalizeDotenvConfigConvention')
+const normalizeDotenvConfigIgnore = require('./helpers/normalizeDotenvConfigIgnore')
 const mask = require('./helpers/mask')
 const maskProcessedEnvs = require('./helpers/maskProcessedEnvs')
 
@@ -43,6 +44,7 @@ function uniqueInjectedKeys (processedEnvs) {
 const config = function (options = {}) {
   options = normalizeDotenvConfigQuiet(options)
   options = normalizeDotenvConfigConvention(options)
+  options = normalizeDotenvConfigIgnore(options)
 
   // allow user to set processEnv to write to
   let processEnv = process.env

--- a/tests/lib/config.test.js
+++ b/tests/lib/config.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const fsx = require('../../src/lib/helpers/fsx')
+const Errors = require('../../src/lib/helpers/errors')
 const os = require('os')
 const path = require('path')
 const sinon = require('sinon')
@@ -209,6 +210,48 @@ t.test('logs any errors thrown from reading file or parsing when in debug mode',
 
   consoleErrorStub.restore()
   readFileXStub.restore()
+})
+
+t.test('respects DOTENV_CONFIG_IGNORE environment variable and does not log matching error', ct => {
+  const consoleErrorStub = sinon.stub(console, 'error')
+
+  const missingEnvFileName = './.env.fake';
+  const missingEnvFileError = new Errors({ envFilepath: missingEnvFileName }).missingEnvFile().messageWithHelp;
+  const callConfig = (options) => dotenvx.config({ path: missingEnvFileName, ...options })
+
+  // control path
+  callConfig()
+  ct.ok(consoleErrorStub.calledWithMatch(sinon.match(missingEnvFileError)))
+  consoleErrorStub.resetHistory();
+
+  process.env.DOTENV_CONFIG_IGNORE = 'MISSING_ENV_FILE';
+  // golden path
+  callConfig()
+  ct.notOk(consoleErrorStub.calledWithMatch(sinon.match(missingEnvFileError)))
+  consoleErrorStub.resetHistory();
+
+  // merge with existing options path
+  callConfig({ ignore: ['FAKE_ERROR'] })
+  ct.notOk(consoleErrorStub.calledWithMatch(sinon.match(missingEnvFileError)))
+  consoleErrorStub.resetHistory();
+
+  for (const ignoreString of [
+    'MISSING_ENV_FILE', // Golden path
+    'MISSING_ENV_FILE,FAKE_ERROR', // Golden path: multiple with MISSING_ENV_FILE first
+    'FAKE_ERROR,MISSING_ENV_FILE', // Golden path: multiple with MISSING_ENV_FILE last
+    'FAKE_ERROR,MISSING_ENV_FILE,FAKE_ERROR_2', // Golden path: multiple with MISSING_ENV_FILE not first or last
+    'MISSING_ENV_FILE,', // Diabolical path: trailing comma
+    ',MISSING_ENV_FILE', // Diabolical path: leading comma
+    ',MISSING_ENV_FILE,', // Diabolical path: leading and trailing comma
+  ]) {
+    process.env.DOTENV_CONFIG_IGNORE = ignoreString;
+    callConfig()
+    ct.notOk(consoleErrorStub.calledWithMatch(sinon.match(missingEnvFileError)))
+    consoleErrorStub.resetHistory();
+  }
+  consoleErrorStub.restore()
+
+  ct.end()
 })
 
 t.test('logs when in debug mode', ct => {


### PR DESCRIPTION
- Allow specifying codes to ignore through the environment instead of via `--ignore`
- If both are specified, the values are merged into a single array