### PR TITLE
Exempt .env.example and .env.x in subdirectories from precommit

### DIFF
--- a/src/lib/services/precommit.js
+++ b/src/lib/services/precommit.js
@@ -54,12 +54,13 @@ class Precommit {
         count += 1
 
         const file = path.join(this.directory, _file) // to handle when directory argument passed
+        const filename = path.basename(file) // exemptions match on filename, so they apply at any depth
 
         // check if file is going to be committed
         if (this._isFileToBeCommitted(file)) {
           // check if that file is being ignored
           if (ig.ignores(file)) {
-            if (file === '.env.example' || file === '.env.x') {
+            if (filename === '.env.example' || filename === '.env.x') {
               const warning = new Errors({
                 message: `${file} ignored (should not be)`,
                 help: `fix: [dotenvx gitignore --pattern !${file}]`
@@ -67,7 +68,7 @@ class Precommit {
               warnings.push(warning)
             }
           } else {
-            if (file !== '.env.example' && file !== '.env.x') {
+            if (filename !== '.env.example' && filename !== '.env.x') {
               const src = fsx.readFileXSync(file)
               const encrypted = sealed(src)
 

--- a/tests/lib/services/precommit.test.js
+++ b/tests/lib/services/precommit.test.js
@@ -220,6 +220,58 @@ t.test('#run (.env files in subfolders throw error in precommit hook)', ct => {
   ct.end()
 })
 
+t.test('#run (.env.example in a subfolder is exempt and does not throw)', ct => {
+  sinon.stub(Precommit.prototype, '_filepaths').returns(['app/.env.example'])
+  childProcess.execSync.returns(Buffer.from('app/.env.example'))
+
+  const readFileXStub = sinon.stub(fsx, 'readFileXSync')
+  readFileXStub.callsFake((filePath) => {
+    if (filePath === 'app/.env.example') {
+      return 'FOOBAR="baz"'
+    }
+    return ''
+  })
+
+  const result = new Precommit().run()
+
+  ct.same(result.successMessage, '▣ encrypted/gitignored (1)')
+  ct.same(result.warnings, [])
+
+  ct.end()
+})
+
+t.test('#run (.env.x in a subfolder is exempt and does not throw)', ct => {
+  sinon.stub(Precommit.prototype, '_filepaths').returns(['app/.env.x'])
+  childProcess.execSync.returns(Buffer.from('app/.env.x'))
+
+  const readFileXStub = sinon.stub(fsx, 'readFileXSync')
+  readFileXStub.callsFake((filePath) => {
+    if (filePath === 'app/.env.x') {
+      return 'FOOBAR="baz"'
+    }
+    return ''
+  })
+
+  const result = new Precommit().run()
+
+  ct.same(result.successMessage, '▣ encrypted/gitignored (1)')
+  ct.same(result.warnings, [])
+
+  ct.end()
+})
+
+t.test('#run (gitignore is ignoring a subfolder .env.example file and shouldn\'t)', ct => {
+  sinon.stub(fsx, 'readFileXSync').returns('.env*')
+  sinon.stub(Precommit.prototype, '_filepaths').returns(['app/.env.example'])
+  childProcess.execSync.returns(Buffer.from('app/.env.example'))
+
+  const { warnings } = new Precommit().run()
+
+  ct.same(warnings[0].message, 'app/.env.example ignored (should not be)')
+
+  ct.end()
+})
+
 t.test('_installPrecommitHook calls InstallPrecommitHook.run', ct => {
   const stub = sinon.stub(InstallPrecommitHook.prototype, 'run').returns({})
 


### PR DESCRIPTION
Fixes #707.

### Problem

`dotenvx precommit` fails on a `.env.example` (or `.env.x`) that lives in a
subdirectory — the usual monorepo layout where each package has its own
`.env` / `.env.example` pair:

```
☠ app/.env.example not encrypted/gitignored. fix: [dotenvx encrypt -f app/.env.example] ...
```

The same file at the repository root passes, which is why the earlier repro
looked fine and the issue was closed.

### Cause

`precommit.js` builds a repo-relative path for the ignore and to-be-committed
checks:

```js
const file = path.join(this.directory, _file)
```

but the `.env.example` / `.env.x` exemptions then compare that **path** against
a bare **filename**:

```js
if (file !== '.env.example' && file !== '.env.x') { ... }
```

so the exemption only fires when the file sits at the top level. Passing the
`[directory]` argument doesn't help — `path.join` reconstructs the same
relative path either way.

### Fix

Compare on `path.basename(file)`, so the exemption applies at any depth. The
full `file` path is still used for logging and for the `ig.ignores` /
`_isFileToBeCommitted` calls. Both exemption branches (the "not
encrypted/gitignored" throw and the "ignored (should not be)" warning) now
match on the basename.

This is the change originally proposed in #794 (95422a976b5824f49ad65d1a85922e7c4ff1dafb), now with tests that fail without the fix so the necessity is asserted.

### Tests

Added three cases to `tests/lib/services/precommit.test.js`:

- `app/.env.example` staged as plaintext is exempt and does not throw
- `app/.env.x` staged as plaintext is exempt and does not throw
- `app/.env.example` wrongly gitignored still warns `... ignored (should not be)`

All three fail on `main` and pass with this change. Every real nested `.env`
is still checked and still required to be sealed — no loss of coverage.
