### PR TITLE
fix precommit skipping .env files at paths git c-quotes

### DIFF
--- a/src/lib/services/precommit.js
+++ b/src/lib/services/precommit.js
@@ -123,8 +123,11 @@ class Precommit {
         return true
       }
 
-      const output = childProcess.execSync('git diff HEAD --name-only').toString()
-      const files = output.split('\n')
+      // -z separates paths with NUL and prints them verbatim. without it git c-quotes
+      // any path holding non-ascii or special characters ("caf\303\251/.env"), which
+      // never matches filePath - the file would be skipped and its secrets committed.
+      const output = childProcess.execSync('git diff HEAD --name-only -z').toString()
+      const files = output.split('\0')
       return files.includes(filePath)
     } catch (error) {
       // consider file to be committed if there is an error (not using git)

--- a/tests/lib/services/precommit.test.js
+++ b/tests/lib/services/precommit.test.js
@@ -220,6 +220,35 @@ t.test('#run (.env files in subfolders throw error in precommit hook)', ct => {
   ct.end()
 })
 
+t.test('#run (.env file at a path git c-quotes is still checked)', ct => {
+  sinon.stub(Precommit.prototype, '_filepaths').returns(['café/.env.production'])
+
+  // git c-quotes any path holding non-ascii or special characters unless -z is passed
+  childProcess.execSync.callsFake((command) => {
+    if (command.includes('rev-parse')) return Buffer.from('true')
+    if (command.includes('-z')) return Buffer.from('café/.env.production\0')
+
+    return Buffer.from('"caf\\303\\251/.env.production"\n')
+  })
+
+  const readFileXStub = sinon.stub(fsx, 'readFileXSync')
+  readFileXStub.callsFake((filePath) => {
+    if (filePath === 'café/.env.production') {
+      return 'ENV_VAR=value'
+    }
+    return ''
+  })
+
+  try {
+    new Precommit().run()
+    ct.fail('should have raised an error but did not')
+  } catch (error) {
+    ct.same(error.message, 'café/.env.production not encrypted/gitignored')
+  }
+
+  ct.end()
+})
+
 t.test('#run (.env.example in a subfolder is exempt and does not throw)', ct => {
   sinon.stub(Precommit.prototype, '_filepaths').returns(['app/.env.example'])
   childProcess.execSync.returns(Buffer.from('app/.env.example'))


### PR DESCRIPTION
`dotenvx ext precommit` silently skips any `.env` file whose path git c-quotes, and reports success. A staged, plaintext, non-gitignored `.env` gets committed with no error.

### Why

`_isFileToBeCommitted` matches the file against `git diff HEAD --name-only`:

```js
const output = childProcess.execSync('git diff HEAD --name-only').toString()
const files = output.split('\n')
return files.includes(filePath)
```

With `core.quotePath` at its default, git wraps any path holding non-ascii or special characters in double quotes and escapes the bytes:

```console
$ git diff HEAD --name-only
.env
"caf\303\251/.env"
sub/.env
```

`files.includes('café/.env')` is then `false`, so the file is treated as not being committed and the encrypted/gitignored check never runs on it. The failure is silent, and it fails open — the success line even counts the file as if it had been checked.

### Reproduction

```console
$ mkdir -p café && printf 'SECRET=plaintext123\n' > café/.env && git add café/.env

$ dotenvx ext precommit
⚠ .gitignore missing. fix: [touch .gitignore]
▣ encrypted/gitignored (1) with warnings (1)
$ echo $?
0
```

The same `.env` at `sub/.env` exits 1 with `☠ sub/.env not encrypted/gitignored`, as it should.

### Fix

Pass `-z`, which makes git NUL-separate the paths and emit them verbatim with no quoting or escaping, and split on `\0`. After the change the file above is caught:

```console
$ dotenvx ext precommit
☠ café/.env not encrypted/gitignored. fix: [dotenvx encrypt -f café/.env] or [dotenvx gitignore --pattern café/.env]
$ echo $?
1
```

Plain-ascii paths and already-encrypted files behave exactly as before — `-z` only changes the separator and the quoting.

### Test

Added to `tests/lib/services/precommit.test.js`. The `execSync` stub mimics git: it returns the c-quoted form for the plain command and the verbatim NUL-separated form when `-z` is present, so the test fails on the old code and only passes if `-z` is actually requested.

`npm run standard` clean, `npm test` 2070/2070 passing.
